### PR TITLE
Include config.h before standard headers

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -19,6 +19,7 @@
  * 02110-1301, USA.
  */
 
+#include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/log.c
+++ b/src/log.c
@@ -19,6 +19,7 @@
  * 02110-1301, USA.
  */
 
+#include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/main.c
+++ b/src/main.c
@@ -19,6 +19,7 @@
  * 02110-1301, USA.
  */
 
+#include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>

--- a/src/options.c
+++ b/src/options.c
@@ -19,6 +19,7 @@
  * 02110-1301, USA.
  */
 
+#include "config.h"
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <string.h>
@@ -28,7 +29,6 @@
 #include <getopt.h>
 #include <termios.h>
 #include <limits.h>
-#include "config.h"
 #include "tio/options.h"
 #include "tio/error.h"
 

--- a/src/time.c
+++ b/src/time.c
@@ -19,6 +19,7 @@
  * 02110-1301, USA.
  */
 
+#include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>

--- a/src/tty.c
+++ b/src/tty.c
@@ -19,6 +19,7 @@
  * 02110-1301, USA.
  */
 
+#include "config.h"
 #include <stdio.h>
 #include <unistd.h>
 #include <string.h>


### PR DESCRIPTION
This makes use of 8d6d202 (Enable large file support) for real.

config.h has to be included before the standard headers as it defines _FILE_OFFSET_BITS.