### PR TITLE
'ctrl-t b' to send serial break.

### DIFF
--- a/man/tio.1
+++ b/man/tio.1
@@ -70,6 +70,8 @@ Display help.
 In session, the following key sequences are intercepted as tio commands:
 .IP "\fBctrl-t ?"
 List available key commands
+.IP "\fBctrl-t b"
+Send serial break (triggers SysRq on Linux, etc.)
 .IP "\fBctrl-t c"
 Show configuration (baudrate, databits, etc.)
 .IP "\fBctrl-t l"

--- a/src/include/tio/tty.h
+++ b/src/include/tio/tty.h
@@ -23,6 +23,7 @@
 #define TTY_H
 
 #define KEY_QUESTION 0x3f
+#define KEY_B 0x62
 #define KEY_C 0x63
 #define KEY_L 0x6C
 #define KEY_Q 0x71

--- a/src/tty.c
+++ b/src/tty.c
@@ -76,12 +76,16 @@ void handle_command_sequence(char input_char, char previous_char, char *output_c
             case KEY_QUESTION:
                 tio_printf("Key commands:");
                 tio_printf(" ctrl-t ?   List available key commands");
+                tio_printf(" ctrl-t b   Send break");
                 tio_printf(" ctrl-t c   Show configuration");
                 tio_printf(" ctrl-t l   Clear screen");
                 tio_printf(" ctrl-t q   Quit");
                 tio_printf(" ctrl-t s   Show statistics");
                 tio_printf(" ctrl-t t   Send ctrl-t key code");
                 *forward = false;
+                break;
+            case KEY_B:
+                tcsendbreak(fd, 0);
                 break;
             case KEY_C:
                 tio_printf("Configuration:");


### PR DESCRIPTION
We need tcsendbreak(), it works akin to SysRq on Linux, with similar functionality on other OSes.

Actually, for me it resets the target immediately, but meh, that's good enough, S-U-B is obsolete nowadays and worse than just B on any modern filesystem.