### PR TITLE
Add missing header file under musl-libc

### DIFF
--- a/src/setspeed2.c
+++ b/src/setspeed2.c
@@ -20,6 +20,7 @@
  */
 
 #include <sys/ioctl.h>
+#include <asm/ioctls.h>
 #include <asm/termbits.h>
 
 int setspeed2(int fd, int baudrate)


### PR DESCRIPTION
Musl's inclusion tree slightly differs from glibc, therefore TCGETS2 is
not reachable through sys/ioctl.h, so asm/ioctls.h needs to be included
too.