### PR TITLE
Write to logfile as soon as we have the data, don't buffer.

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -40,6 +40,7 @@ void log_open(const char *filename)
         log_error = true;
         exit(EXIT_FAILURE);
     }
+    setvbuf(fp, NULL, _IONBF, 0);
 }
 
 void log_write(char c)


### PR DESCRIPTION
Logfiles are important to see what happend, in particular if something
unexpected happened; so we want to make sure that the logfile is flushed
to disk.

Before this change, the logfile was typically written at the end in
a large chunk as the default (large) buffering applied. Now, characters are
written out ASAP, so it is possible to get a live-view with a
tail -f <logfile>