### PR TITLE
tty: Bail out if the TTY is not accessible

### DIFF
--- a/src/include/tio/tty.h
+++ b/src/include/tio/tty.h
@@ -42,6 +42,7 @@ void stdout_configure(void);
 void stdout_restore(void);
 void stdin_configure(void);
 void stdin_restore(void);
+void tty_check(void);
 void tty_configure(void);
 int tty_connect(void);
 void tty_wait_for_device(void);

--- a/src/main.c
+++ b/src/main.c
@@ -39,6 +39,9 @@ int main(int argc, char *argv[])
     /* Parse options */
     parse_options(argc, argv);
 
+    /* Check tty */
+    tty_check();
+
     /* Configure tty device */
     tty_configure();
 

--- a/src/tty.c
+++ b/src/tty.c
@@ -276,6 +276,15 @@ void stdout_restore(void)
     tcsetattr(STDOUT_FILENO, TCSANOW, &stdout_old);
 }
 
+void tty_check(void)
+{
+    if (access(option.tty_device, R_OK) != 0)
+    {
+        error_printf("Could not access the TTY (%s)", strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+}
+
 void tty_configure(void)
 {
     bool token_found = true;
@@ -504,10 +513,6 @@ void tty_wait_for_device(void)
             error_printf("select() failed (%s)", strerror(errno));
             exit(EXIT_FAILURE);
         }
-
-        /* Test for accessible device file */
-        if (access(option.tty_device, R_OK) == 0)
-            return;
     }
 }
 


### PR DESCRIPTION
One common problem when accessing the TTY is that you cannot access it
as regular user. The expected behavior is that the TTY terminal
application errors this out to the user. TIO is simply looping trying to
endlessly access the TTY, leaving the user in the dark about what's
going on.

The underlying issue is that the access checking is done in a void
returning function (tty_wait_for_device()) that is basically doing
nothing when the (access()) function is failing (because the TTY is not
accessible).

Move the check for the TTY accessibility at the start, even before
configuring the TTY because why do we need to configure a TTY that we
cannot even access?

Signed-off-by: Carlo Caione <ccaione@baylibre.com>