### PR TITLE
Flush every local echo-ed char

### DIFF
--- a/src/tty.c
+++ b/src/tty.c
@@ -535,6 +535,7 @@ static void optional_local_echo(char c)
     if (!option.local_echo)
         return;
     print(c);
+    fflush(stdout);
     if (option.log)
         log_write(c);
 }


### PR DESCRIPTION
At least on OS X (10.11), local echo only prints everything after a newline is sent, which is not very convenient. So force flush the stdout after every character is typed.

Tested on a mac only, don't have any Linux nearby.