### PR TITLE
Disable line buffering in stdout

### DIFF
--- a/src/tty.c
+++ b/src/tty.c
@@ -234,6 +234,10 @@ void stdout_configure(void)
 {
     int status;
 
+    /* Disable line buffering in stdout. This is necessary if we
+     * want things like local echo to work correctly. */
+    setbuf(stdout, NULL);
+
     /* Save current stdout settings */
     if (tcgetattr(STDOUT_FILENO, &stdout_old) < 0)
     {


### PR DESCRIPTION
In order for local echo to work properly, we have to either call
fflush(stdout) after every character or just disable line buffering.
This change uses setbuf(stdout, NULL) to do the latter.

Closes #92