### PR TITLE
fflush() after putchar() for print_hex and print_normal

### DIFF
--- a/src/tty.c
+++ b/src/tty.c
@@ -70,11 +70,13 @@ static bool map_o_del_bs = false;
 static void print_hex(char c)
 {
     printf("%02x ", (unsigned char) c);
+    fflush(stdout);
 }
 
 static void print_normal(char c)
 {
     putchar(c);
+    fflush(stdout);
 }
 
 void handle_command_sequence(char input_char, char previous_char, char *output_char, bool *forward)


### PR DESCRIPTION
In order for local echo to work properly, we have to either call
fflush(stdout) after every character or just disable line buffering.
This change calls fflush() after putchar().

Closes #92