### PR TITLE
Adds ICRCRNL flag to map <CR> to <CR><NL> on input

### DIFF
--- a/man/tio.1
+++ b/man/tio.1
@@ -76,6 +76,8 @@ Ignore CR on input.
 Map NL to CR on input.
 .IP "\fBINLCRNL"
 Map NL to CR-NL on input.
+.IP "\fBICRCRNL"
+Map CR to CR-NL on input.
 .IP "\fBOCRNL"
 Map CR to NL on output.
 .IP "\fBODELBS"

--- a/src/tty.c
+++ b/src/tty.c
@@ -56,6 +56,7 @@ static bool standard_baudrate = true;
 static void (*print)(char c);
 static int fd;
 static bool map_i_nl_crnl = false;
+static bool map_i_cr_crnl = false;
 static bool map_o_cr_nl = false;
 static bool map_o_nl_crnl = false;
 static bool map_o_del_bs = false;
@@ -439,6 +440,8 @@ void tty_configure(void)
                 map_o_del_bs = true;
             else if (strcmp(token,"INLCRNL") == 0)
                 map_i_nl_crnl = true;
+            else if (strcmp(token,"ICRCRNL") == 0)
+                map_i_cr_crnl = true;
             else if (strcmp(token, "ONLCRNL") == 0)
                 map_o_nl_crnl = true;
             else
@@ -647,6 +650,12 @@ int tty_connect(void)
 
                     /* Map input character */
                     if ((input_char == '\n') && (map_i_nl_crnl))
+                    {
+                        print('\r');
+                        print('\n');
+                        if (option.timestamp)
+                            next_timestamp = time(NULL);
+                    } else if ((input_char == '\r') && (map_i_cr_crnl))
                     {
                         print('\r');
                         print('\n');


### PR DESCRIPTION
I'm working with a device that terminates command with a bare `<CR>`.
This results in everything on the same line, which is confusing.
Remapping that bare `<CR>` to `<CR><NL>` makes it much easier to work
with, and this seems like a natural counterpart to INLCRNL.