### PR TITLE
Exit if output speed cannot be set.

### DIFF
--- a/src/tty.c
+++ b/src/tty.c
@@ -323,7 +323,7 @@ void tty_configure(void)
         }
 
         // Set output speed
-        cfsetospeed(&tio, baudrate);
+        status = cfsetospeed(&tio, baudrate);
         if (status == -1)
         {
             error_printf("Could not configure output speed (%s)", strerror(errno));


### PR DESCRIPTION
I have not tested this, but it looks like a bug.