### PR TITLE
src/setspeed2.c: fix redefinition of termio

### DIFF
--- a/src/setspeed2.c
+++ b/src/setspeed2.c
@@ -20,8 +20,8 @@
  */
 
 #include <sys/ioctl.h>
-#include <asm/ioctls.h>
-#include <asm/termbits.h>
+#include <asm-generic/ioctls.h>
+#include <asm-generic/termbits.h>
 
 int setspeed2(int fd, int baudrate)
 {


### PR DESCRIPTION
Include ioctls.h and termbits.h from asm-generic instead of asm to avoid
the following build failure:

```
In file included from setspeed2.c:24:0:
/home/naourr/work/instance-0/output-1/host/sparc64-buildroot-linux-gnu/sysroot/usr/include/asm/termbits.h:17:8: error: redefinition of 'struct termio'
 struct termio {
        ^~~~~~
In file included from /home/naourr/work/instance-0/output-1/host/sparc64-buildroot-linux-gnu/sysroot/usr/include/sys/ioctl.h:29:0,
                 from setspeed2.c:22:
/home/naourr/work/instance-0/output-1/host/sparc64-buildroot-linux-gnu/sysroot/usr/include/bits/ioctl-types.h:36:8: note: originally defined here
 struct termio
        ^~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/1a7418b9cd11374a250f7509d5bddcc864375e1c

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>