### PR TITLE
Fix out of tree builds

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,3 +1,4 @@
+AM_CPPFLAGS = -I$(srcdir)/include
 AM_CFLAGS = -Wall
 bin_PROGRAMS = tio
 tio_SOURCES = tty.c \


### PR DESCRIPTION
Out of tree builds are currently broken because $(top_srcdir)src/include
is not in the search path. In tree builds are working because autconf add
$(top_builddir)/src/include to the search path for the generated config.h.
As $(top_builddir) and $(top_srcdir) are identical during in tree builds
the search path still end up beeing somehow correct.

To fix this add -I$(srcdir)/include to the CPPFLAGS in Makefile.am.