### PR TITLE
Show error when failing to open a tty

### DIFF
--- a/src/tty.c
+++ b/src/tty.c
@@ -460,6 +460,7 @@ void tty_wait_for_device(void)
     struct timeval tv;
     static char input_char, previous_char = 0;
     static bool first = true;
+    static int last_errno = 0;
 
     /* Loop until device pops up */
     while (true)
@@ -506,8 +507,15 @@ void tty_wait_for_device(void)
         }
 
         /* Test for accessible device file */
-        if (access(option.tty_device, R_OK) == 0)
+        int rc = access(option.tty_device, R_OK);
+        if (rc == 0) {
+            last_errno = 0;
             return;
+        }
+        else if (last_errno != errno) {
+            tio_printf("%s: %s. Waiting...", option.tty_device, strerror(errno));
+            last_errno = errno;
+        }
     }
 }
 


### PR DESCRIPTION
This fixes the complaint in #81 by printing the reason why a tty hasn't been successfully connected yet.

Example when a device is plugged in and out while tio is running:
```
[15:25:49] tio v1.32
[15:25:49] Press ctrl-t q to quit
[15:25:49] /dev/ttyUSB1: No such file or directory. Waiting...
[15:26:00] Connected
[15:26:02] Disconnected
[15:26:03] /dev/ttyUSB1: No such file or directory. Waiting...
```

Example when user doesn't have permission to open tty:
```
[15:17:00] tio v1.32
[15:17:00] Press ctrl-t q to quit
[15:17:00] /dev/ttyUSB0: Permission denied. Waiting...
```