### PR TITLE
Local echo: show character by character even if stdout buffered.

### DIFF
--- a/src/tty.c
+++ b/src/tty.c
@@ -535,6 +535,7 @@ static void optional_local_echo(char c)
     if (!option.local_echo)
         return;
     print(c);
+    fflush(stdout);
     if (option.log)
         log_write(c);
 }


### PR DESCRIPTION
If stdout is buffered with `putchar()`, local echo will not print anything until the next return. Make sure output is flushed so that each typed character shows up immediately.

(This used to work, not sure when it broke)