### PR TITLE
Make comparison POSIX compliant

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -86,7 +86,7 @@ AC_DEFINE_UNQUOTED([AUTOCONF_BAUDRATE_CASES],[$BAUDRATE_CASES],[Switch cases for
 
 # Check for interface for setting arbitrary I/O speeds
 AC_CHECK_DECL([TCGETS2], [AC_DEFINE([HAVE_TERMIOS2],[1],[Define if termios2 exists.]) have_termios2=yes], , [[#include <asm/termios.h>]])
-AM_CONDITIONAL([ADD_SETSPEED2],[test "x$have_termios2" == "xyes"])
+AM_CONDITIONAL([ADD_SETSPEED2],[test "x$have_termios2" = "xyes"])
 
 AC_CONFIG_FILES([Makefile])
 AC_CONFIG_FILES([src/Makefile])


### PR DESCRIPTION
String comparison with == is not POSIX compliant and can fail with e.g.
dash.

Fixes https://github.com/tio/tio/issues/115