### PR TITLE
Output newline on stdout with hex print mode

### DIFF
--- a/src/tty.c
+++ b/src/tty.c
@@ -70,7 +70,12 @@ static bool map_o_del_bs = false;
 
 static void print_hex(char c)
 {
-    printf("%02x ", (unsigned char) c);
+
+    if ((c == '\n') || (c == '\r'))
+        printf("%c", c);
+    else
+        printf("%02x ", (unsigned char) c);
+
     fflush(stdout);
 }
 


### PR DESCRIPTION
This is to fix the issue #104. The timestamp will always be
printed at the beginning of line:

[10:25:56] Switched to hexadecimal mode
0d 0a 0d [10:25:57] 41 43 52 4e 3a 5c 3e 0d 0a 0d [10:25:58] 41

is changed to:

[12:34:56] 45 72 72 6f 72 3a 20 49 6e 76 61 6c 69 64 20
[12:34:56] 41 43 52 4e 3a 5c 3e
[12:34:56] 41 43 52 4e 3a 5c 3e
[12:34:57] 41 43 52 4e 3a 5c 3e 6c 73