### PR TITLE
Support non standard bauds on mac and a new option to send/clear break

### DIFF
--- a/man/tio.1
+++ b/man/tio.1
@@ -103,6 +103,8 @@ In session, the following key sequences are intercepted as tio commands:
 List available key commands
 .IP "\fBctrl-t b"
 Send serial break (triggers SysRq on Linux, etc.)
+.IP "\fBctrl-t B"
+Send serial break and clear manually
 .IP "\fBctrl-t c"
 Show configuration (baudrate, databits, etc.)
 .IP "\fBctrl-t e"

--- a/src/include/tio/tty.h
+++ b/src/include/tio/tty.h
@@ -24,6 +24,7 @@
 
 #define KEY_QUESTION 0x3f
 #define KEY_B 0x62
+#define KEY_SHIFT_B 0x42
 #define KEY_C 0x63
 #define KEY_E 0x65
 #define KEY_H 0x68

--- a/src/time.c
+++ b/src/time.c
@@ -23,24 +23,25 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
+#include <sys/time.h>
 #include "tio/error.h"
 #include "tio/print.h"
 
 char * current_time(void)
 {
     static char time_string[20];
-    time_t t;
     struct tm *tmp;
+    struct timeval tv;
 
-    t = time(NULL);
-    tmp = localtime(&t);
+    gettimeofday(&tv, NULL);
+    tmp = localtime(&tv.tv_sec);
     if (tmp == NULL)
     {
         error_printf("Retrieving local time failed");
         exit(EXIT_FAILURE);
     }
 
-    strftime(time_string, sizeof(time_string), "%H:%M:%S", tmp);
+    sprintf(time_string, "%2d:%02d:%02d.%03d",  tmp->tm_hour,  tmp->tm_min, tmp->tm_sec, tv.tv_usec/1000);
 
     return time_string;
 }


### PR DESCRIPTION
This PR makes non standard baud rates work on Mac.
Also I have added a new option send/clear break. It gives user the ability to manually clear the break signal instead of relying on fixed duration of 0.5 seconds. I have a use case where I need it.