### PR TITLE
add support for high bps on OS X

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -88,6 +88,9 @@ AC_DEFINE_UNQUOTED([AUTOCONF_BAUDRATE_CASES],[$BAUDRATE_CASES],[Switch cases for
 AC_CHECK_DECL([TCGETS2], [AC_DEFINE([HAVE_TERMIOS2],[1],[Define if termios2 exists.]) have_termios2=yes], , [[#include <asm/termios.h>]])
 AM_CONDITIONAL([ADD_SETSPEED2],[test "x$have_termios2" = "xyes"])
 
+AC_CHECK_DECL([IOSSIOSPEED], [AC_DEFINE([HAVE_IOSSIOSPEED],[1],[Define if IOKit exists.]) have_iossiospeed=yes], , [[#include <IOKit/serial/ioss.h>]])
+AM_CONDITIONAL([ADD_IOSSIOSPEED],[test "x$have_iossiospeed" = "xyes"])
+
 AC_CONFIG_FILES([Makefile])
 AC_CONFIG_FILES([src/Makefile])
 AC_CONFIG_FILES([src/bash-completion/tio])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -18,6 +18,10 @@ if ADD_SETSPEED2
 tio_SOURCES += setspeed2.c
 endif
 
+if ADD_IOSSIOSPEED
+tio_SOURCES += iossiospeed.c
+endif
+
 if ENABLE_BASH_COMPLETION
 bashcompletiondir=@BASH_COMPLETION_DIR@
 bashcompletion_DATA=bash-completion/tio

--- a/src/iossiospeed.c
+++ b/src/iossiospeed.c
@@ -1,0 +1,28 @@
+/*
+ * tio - a simple TTY terminal I/O application
+ *
+ * Copyright (c) 2017  Martin Lund
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include <sys/ioctl.h>
+#include <IOKit/serial/ioss.h>
+
+int iossiospeed(int fd, int baudrate)
+{
+    return ioctl(fd, IOSSIOSPEED, (char *)&baudrate);
+}


### PR DESCRIPTION
It's me again to cause more trouble!

I figured out how to support high speeds (1Mbps, 2Mbps, ...) on OS X by peeking at how pyserial does it, and it seems relatively straightforward. This works at least on my macbook running Mojave.