### PR TITLE
Fix timestamp parsing in INI conf

### DIFF
--- a/src/configfile.c
+++ b/src/configfile.c
@@ -34,6 +34,7 @@
 #include <unistd.h>
 #include <regex.h>
 #include <ini.h>
+#include "options.h"
 #include "configfile.h"
 #include "misc.h"
 #include "options.h"
@@ -135,7 +136,7 @@ static int data_handler(void *user, const char *section, const char *name,
         }
         else if (!strcmp(name, "timestamp"))
         {
-            option.timestamp = atoi(value);
+            option.timestamp = timestamp_option_parse(value);
         }
         else if (!strcmp(name, "log-filename"))
         {
@@ -259,4 +260,12 @@ void config_exit(void)
     free(c->path);
 
     free(c);
+}
+
+void config_file_print()
+{
+    tio_printf("INI:");
+    tio_printf(" path: %s", c->path);
+    tio_printf(" searched section: %s", c->user);
+    tio_printf(" found section: %s", c->section_name);
 }

--- a/src/configfile.h
+++ b/src/configfile.h
@@ -37,5 +37,6 @@ struct config_t
 	char *map;
 };
 
+void config_file_print();
 void config_file_parse(const int argc, char *argv[]);
 void config_exit(void);

--- a/src/main.c
+++ b/src/main.c
@@ -77,6 +77,11 @@ int main(int argc, char *argv[])
     /* Print launch hints */
     tio_printf("tio v%s", VERSION);
     tio_printf("Press ctrl-t q to quit");
+    if (option.debug)
+    {
+        config_file_print();
+        options_print();
+    }
 
     /* Connect to tty device */
     if (option.no_autoconnect)

--- a/src/options.h
+++ b/src/options.h
@@ -33,6 +33,8 @@ enum timestamp_t
     TIMESTAMP_24HOUR_START,
     TIMESTAMP_ISO8601,
 };
+const char* timestamp_token(enum timestamp_t timestamp);
+enum timestamp_t timestamp_option_parse(const char *arg);
 
 /* Options */
 struct option_t
@@ -52,8 +54,10 @@ struct option_t
     const char *log_filename;
     const char *map;
     int color;
+    bool debug;
 };
 
 extern struct option_t option;
 
+void options_print();
 void options_parse(int argc, char *argv[]);

--- a/src/tty.c
+++ b/src/tty.c
@@ -163,21 +163,7 @@ void handle_command_sequence(char input_char, char previous_char, char *output_c
                 break;
 
             case KEY_C:
-                tio_printf("Configuration:");
-                tio_printf(" TTY device: %s", option.tty_device);
-                tio_printf(" Baudrate: %u", option.baudrate);
-                tio_printf(" Databits: %d", option.databits);
-                tio_printf(" Flow: %s", option.flow);
-                tio_printf(" Stopbits: %d", option.stopbits);
-                tio_printf(" Parity: %s", option.parity);
-                tio_printf(" Local echo: %s", option.local_echo ? "enabled" : "disabled");
-                tio_printf(" Timestamps: %s", option.timestamp ? "enabled" : "disabled");
-                tio_printf(" Output delay: %d", option.output_delay);
-                tio_printf(" Auto connect: %s", option.no_autoconnect ? "disabled" : "enabled");
-                if (option.map[0] != 0)
-                    tio_printf(" Map flags: %s", option.map);
-                if (option.log)
-                    tio_printf(" Log file: %s", option.log_filename);
+                options_print();
                 break;
 
             case KEY_E:


### PR DESCRIPTION
Hi Martin,

Here is a patch that factorises timestamp parsing in order to be coherent with command line format (24hour ... iso8601), not 1/2/3 !
Also adds an "hidden" -V CLI option to display silent INI file operations.

Cheers,
Sly