### PR TITLE
Add support for external control via a Unix domain socket.

### DIFF
--- a/man/tio.1.in
+++ b/man/tio.1.in
@@ -115,6 +115,17 @@ Colorize tio text using ANSI color code ranging from 0 to 255.
 If color code is negative a list of available ANSI colors will be printed.
 
 .TP
+.BR \-S ", " "\-\-socket unix:\fI<filename>\fR\fB
+
+Listen on a Unix domain socket at the specified path. Any input from clients connected to the socket is sent on the serial port as if entered at the terminal where tio is running (except that
+.B ctrl-t
+sequences are not recognized), and any input from the serial port is multiplexed to the terminal and all connected clients.
+
+Sockets remain open while the serial port is disconnected, and writes will block.
+
+At present there is a hardcoded limit of 16 clients connected at one time.
+
+.TP
 .BR \-v ", " \-\-version
 
 Display program version.
@@ -201,6 +212,9 @@ Set log filename
 Map special characters on input or output
 .IP "\fBcolor"
 Colorize tio text using ANSI color code ranging from 0 to 255.
+.IP "\fBsocket"
+Set socket path (must include
+.BR unix: ).
 
 .SH "CONFIGURATION EXAMPLES"
 

--- a/src/bash-completion/tio.in
+++ b/src/bash-completion/tio.in
@@ -80,6 +80,10 @@ _tio()
             COMPREPLY=( $(compgen -W "$(seq 0 255)" -- ${cur}) )
             return 0
             ;;
+        -S | --socket)
+            COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+            return 0
+            ;;
         -v | --version)
             COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
             return 0

--- a/src/configfile.c
+++ b/src/configfile.c
@@ -152,6 +152,11 @@ static int data_handler(void *user, const char *section, const char *name,
         {
             option.color = atoi(value);
         }
+        else if (!strcmp(name, "socket"))
+        {
+            asprintf(&c->socket, "%s", value);
+            option.socket = c->socket;
+        }
     }
     return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -30,6 +30,7 @@
 #include "error.h"
 #include "print.h"
 #include "signals.h"
+#include "socket.h"
 
 int main(int argc, char *argv[])
 {
@@ -70,6 +71,9 @@ int main(int argc, char *argv[])
     /* Create log file */
     if (option.log)
         log_open(option.log_filename);
+
+    /* Open socket */
+    socket_configure();
 
     /* Enable ANSI text formatting (colors etc.) */
     print_enable_ansi_formatting();

--- a/src/meson.build
+++ b/src/meson.build
@@ -12,7 +12,8 @@ tio_sources = [
   'tty.c',
   'print.c',
   'configfile.c',
-  'signals.c'
+  'signals.c',
+  'socket.c'
 ]
 
 tio_dep = dependency('inih', required: true,

--- a/src/options.c
+++ b/src/options.c
@@ -51,6 +51,7 @@ struct option_t option =
     .timestamp = TIMESTAMP_NONE,
     .list_devices = false,
     .log_filename = "",
+    .socket = NULL,
     .map = "",
     .color = -1,
 };
@@ -73,6 +74,7 @@ void print_help(char *argv[])
     printf("  -l, --log[=<filename>]      Log to file\n");
     printf("  -m, --map <flags>           Map special characters\n");
     printf("  -c, --color <code>          Colorize tio text\n");
+    printf("  -S, --socket <filename>     Listen on domain socket\n");
     printf("  -v, --version               Display version\n");
     printf("  -h, --help                  Display help\n");
     printf("\n");
@@ -174,6 +176,7 @@ void options_parse(int argc, char *argv[])
             {"timestamp",      optional_argument, 0, 't'},
             {"list-devices",   no_argument,       0, 'L'},
             {"log",            optional_argument, 0, 'l'},
+            {"socket",         required_argument, 0, 'S'},
             {"map",            required_argument, 0, 'm'},
             {"color",          required_argument, 0, 'c'},
             {"version",        no_argument,       0, 'v'},
@@ -185,7 +188,7 @@ void options_parse(int argc, char *argv[])
         int option_index = 0;
 
         /* Parse argument using getopt_long */
-        c = getopt_long(argc, argv, "b:d:f:s:p:o:net::Ll::m:c:vh", long_options, &option_index);
+        c = getopt_long(argc, argv, "b:d:f:s:p:o:net::Ll:S::m:c:vh", long_options, &option_index);
 
         /* Detect the end of the options */
         if (c == -1)
@@ -246,6 +249,10 @@ void options_parse(int argc, char *argv[])
             case 'l':
                 option.log = true;
                 option.log_filename = optarg;
+                break;
+
+            case 'S':
+                option.socket = optarg;
                 break;
 
             case 'm':

--- a/src/options.h
+++ b/src/options.h
@@ -53,6 +53,7 @@ struct option_t
     bool list_devices;
     const char *log_filename;
     const char *map;
+    const char *socket;
     int color;
 };
 

--- a/src/socket.c
+++ b/src/socket.c
@@ -1,0 +1,195 @@
+/*
+ * tio - a simple serial terminal I/O tool
+ *
+ * Copyright (c) 2014-2022  Martin Lund
+ * Copyright (c) 2022  Google LLC
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include "socket.h"
+#include "options.h"
+#include "print.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#define MAX_SOCKET_CLIENTS 16
+
+static int sockfd;
+static int clientfds[MAX_SOCKET_CLIENTS];
+
+static const char *socket_filename(void)
+{
+    /* skip 'unix:' */
+    return option.socket + 5;
+}
+
+static void socket_exit(void)
+{
+    unlink(socket_filename());
+}
+
+void socket_configure(void)
+{
+    if (!option.socket)
+    {
+        return;
+    }
+
+    if (strncmp(option.socket, "unix:", 5) != 0)
+    {
+        error_printf("%s: Invalid socket scheme, must be 'unix:'", option.socket);
+        exit(EXIT_FAILURE);
+    }
+
+    struct sockaddr_un sockaddr = {};
+    if (strlen(socket_filename()) > sizeof(sockaddr.sun_path) - 1)
+    {
+        error_printf("Socket file path %s too long", option.socket);
+        exit(EXIT_FAILURE);
+    }
+ 
+    sockaddr.sun_family = AF_UNIX;
+    strncpy(sockaddr.sun_path, socket_filename(), sizeof(sockaddr.sun_path) - 1);
+
+    sockfd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (sockfd < 0)
+    {
+        error_printf("Failed to create socket: %s", strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+
+    unlink(socket_filename());
+    if (bind(sockfd, (struct sockaddr *)&sockaddr, sizeof(sockaddr)) < 0)
+    {
+        error_printf("Failed to bind to socket %s: %s", socket_filename(), strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+
+    if (listen(sockfd, MAX_SOCKET_CLIENTS) < 0)
+    {
+        error_printf("Failed to listen on socket %s: %s", socket_filename(), strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+
+    memset(clientfds, -1, sizeof(clientfds));
+    atexit(socket_exit);
+}
+
+void socket_write(char input_char)
+{
+    if (!option.socket)
+    {
+        return;
+    }
+
+    for (int i = 0; i != MAX_SOCKET_CLIENTS; ++i)
+    {
+        if (clientfds[i] != -1)
+        {
+            if (write(clientfds[i], &input_char, 1) <= 0)
+            {
+                error_printf_silent("Failed to write to socket: %s", strerror(errno));
+                close(clientfds[i]);
+                clientfds[i] = -1;
+            }
+        }
+    }
+}
+
+int socket_add_fds(fd_set *rdfs, bool connected)
+{
+    if (!option.socket)
+    {
+        return 0;
+    }
+
+    int numclients = 0, maxfd = 0;
+    for (int i = 0; i != MAX_SOCKET_CLIENTS; ++i)
+    {
+        if (clientfds[i] != -1)
+        {
+            /* let clients block if they try to send while we're disconnected */
+            if (connected)
+            {
+                FD_SET(clientfds[i], rdfs);
+                maxfd = MAX(maxfd, clientfds[i]);
+            }
+            numclients++;
+        }
+    }
+    /* don't bother to accept clients if we're already full */
+    if (numclients != MAX_SOCKET_CLIENTS)
+    {
+        FD_SET(sockfd, rdfs);
+        maxfd = MAX(maxfd, sockfd);
+    }
+    return maxfd;
+}
+
+bool socket_handle_input(fd_set *rdfs, char *output_char)
+{
+    if (!option.socket)
+    {
+        return false;
+    }
+
+    if (FD_ISSET(sockfd, rdfs))
+    {
+        int clientfd = accept(sockfd, NULL, NULL);
+        /* this loop should always succeed because we don't select on sockfd when full */
+        for (int i = 0; i != MAX_SOCKET_CLIENTS; ++i)
+        {
+            if (clientfds[i] == -1)
+            {
+                clientfds[i] = clientfd;
+                break;
+            }
+        }
+    }
+    for (int i = 0; i != MAX_SOCKET_CLIENTS; ++i)
+    {
+        if (clientfds[i] != -1 && FD_ISSET(clientfds[i], rdfs))
+        {
+            int status = read(clientfds[i], output_char, 1);
+            if (status == 0)
+            {
+                close(clientfds[i]);
+                clientfds[i] = -1;
+                continue;
+            }
+            if (status < 0)
+            {
+                error_printf_silent("Failed to read from socket: %s", strerror(errno));
+                close(clientfds[i]);
+                clientfds[i] = -1;
+                continue;
+            }
+            /* match the behavior of a terminal in raw mode */
+            if (*output_char == '\n')
+            {
+                *output_char = '\r';
+            }
+            return true;
+        }
+    }
+    return false;
+}

--- a/src/socket.h
+++ b/src/socket.h
@@ -1,8 +1,8 @@
 /*
  * tio - a simple serial terminal I/O tool
  *
- * Copyright (c) 2020  Liam Beguin
- * Copyright (c) 2022  Martin Lund
+ * Copyright (c) 2014-2022  Martin Lund
+ * Copyright (c) 2022  Google LLC
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -22,22 +22,10 @@
 
 #pragma once
 
-struct config_t
-{
-	const char *user;
+#include <stdbool.h>
+#include <sys/select.h>
 
-	char *path;
-	char *section_name;
-	char *match;
-
-	char *tty;
-	char *flow;
-	char *parity;
-	char *log_filename;
-	char *socket;
-	char *map;
-};
-
-void config_file_print();
-void config_file_parse(const int argc, char *argv[]);
-void config_exit(void);
+void socket_configure(void);
+void socket_write(char input_char);
+int socket_add_fds(fd_set *fds, bool connected);
+bool socket_handle_input(fd_set *fds, char *output_char);


### PR DESCRIPTION
This feature allows an external program to inject output into and
listen to input from a serial port via a Unix domain socket (path
specified via the -S/--socket command line flag, or the socket
config file option) while tio is running. This is useful for ad-hoc
scripting of serial port interactions while still permitting manual
control. Since many serial devices (at least on Linux) get confused
when opened by multiple processes, and most commands do not know
how to correctly open a serial device, this allows a more convenient
usage model than directly writing to the device node from an external
program.

Any input from clients connected to the socket is sent on the serial
port as if entered at the terminal where tio is running (except that
ctrl-t sequences are not recognized), and any input from the serial
port is multiplexed to the terminal and all connected clients.

Sockets remain open while the serial port is disconnected, and writes
will block.

Example usage 1 (issue a command):

  echo command | nc -UN /path/to/socket > /dev/null

Example usage 2 (use the expect command to script an interaction):

  #!/usr/bin/expect -f

  set timeout -1
  log_user 0

  spawn nc -UN /path/to/socket
  set uart $spawn_id

  send -i $uart "command1\n"
  expect -i $uart "prompt> "
  send -i $uart "command2\n"
  expect -i $uart "prompt> "