### PR TITLE
Match user input against config section names if pattern matching was…

### DIFF
--- a/man/tio.1.in
+++ b/man/tio.1.in
@@ -183,6 +183,9 @@ Sections can be used to group settings and their names are only used for readabi
 tio will try to match the user input to a section pattern to get the tty and other options.
 
 .TP
+If pattern matching fails, tio will try to match the user input to a section name.
+
+.TP
 Options without any section name sets the default options.
 
 .TP


### PR DESCRIPTION
… unsuccessful.

This allows for better config file ergonomics if the user has a diverse
set of serial devices as the name does not need to be specified in
the config file twice.