### PR TITLE
handle malloc failure

### DIFF
--- a/src/configfile.c
+++ b/src/configfile.c
@@ -320,6 +320,11 @@ void config_file_parse(void)
     int ret;
 
     c = malloc(sizeof(struct config_t));
+    if (!c)
+    {
+        fprintf(stderr, "Error: Insufficient memory allocation");
+        exit(EXIT_FAILURE);
+    } 
     memset(c, 0, sizeof(struct config_t));
 
     // Find config file


### PR DESCRIPTION
If the malloc function failed to allocate memory, it is unlikely that the program will continue to function properly the null pointer returned will leads almost always to fatal error in the program .