### PR TITLE
Add Pulse DTR command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ when used in combination with [tmux](https://tmux.github.io).
  * List available serial devices
  * Show RX/TX statistics
  * Toggle serial lines
+ * Pulse the DTR line
  * Local echo support
  * Remap special characters (nl, cr-nl, bs, etc.)
  * Line timestamps
@@ -65,6 +66,7 @@ The command-line interface is straightforward as reflected in the output from
       -s, --stopbits 1|2               Stop bits (default: 1)
       -p, --parity odd|even|none       Parity (default: none)
       -o, --output-delay <ms>          Character output delay (default: 0)
+          --dtr-pulse-duration <ms>    DTR pulse duration (default: 100)
       -n, --no-autoconnect             Disable automatic connect
       -e, --local-echo                 Enable local echo
       -t, --timestamp                  Enable line timestamp
@@ -125,6 +127,7 @@ ctrl-t ? to list the available key commands.
 [20:19:12.040]  ctrl-t b   Send break
 [20:19:12.040]  ctrl-t c   Show configuration
 [20:19:12.040]  ctrl-t d   Toggle DTR line
+[20:19:12.040]  ctrl-t D   Pulse DTR line
 [20:19:12.040]  ctrl-t e   Toggle local echo mode
 [20:19:12.040]  ctrl-t h   Toggle hexadecimal mode
 [20:19:12.040]  ctrl-t l   Clear screen
@@ -158,6 +161,7 @@ databits = 8
 parity = none
 stopbits = 1
 color = 10
+dtr-pulse-duration = 50
 
 [rpi3]
 tty = /dev/serial/by-id/usb-FTDI_TTL232R-3V3_FTGQVXBL-if00-port0

--- a/man/tio.1.in
+++ b/man/tio.1.in
@@ -41,6 +41,12 @@ Set parity (default: none).
 .BR \-o ", " "\-\-output\-delay " \fI<ms>
 
 Set output delay [ms] inserted between each sent character (default: 0).
+
+.TP
+.BR "    \-\-dtr\-pulse\-duration " \fI<ms>
+
+Set the duration [ms] of the DTR pulse (default: 100).
+
 .TP
 .BR \-n ", " \-\-no\-autoconnect
 
@@ -199,6 +205,8 @@ Send ctrl-t key code
 Show line states (DTR, RTS, CTS, DSR, DCD, RI)
 .IP "\fBctrl-t d"
 Toggle DTR
+.IP "\fBctrl-t D"
+Pulse DTR
 .IP "\fBctrl-t r"
 Toggle RTS
 .IP "\fBctrl-t v"
@@ -254,6 +262,8 @@ Set stop bits
 Set parity
 .IP "\fBoutput-delay"
 Set output delay
+.IP "\fBdtr-pulse-duration"
+Set DTR pulse duration
 .IP "\fBno-autoconnect"
 Disable automatic connect
 .IP "\fBlog"
@@ -291,6 +301,7 @@ databits = 8
 parity = none
 stopbits = 1
 color = 10
+dtr-pulse-duration = 50
 .ec
 .fi
 .RE

--- a/src/bash-completion/tio.in
+++ b/src/bash-completion/tio.in
@@ -16,6 +16,7 @@ _tio()
           -s --stopbits \
           -p --parity \
           -o --output-delay \
+             --dtr-pulse-duration \
           -n --no-autoconnect \
           -e --local-echo \
           -l --log \
@@ -56,6 +57,10 @@ _tio()
             ;;
         -o | --output-delay)
             COMPREPLY=( $(compgen -W "0 1 10 100" -- ${cur}) )
+            return 0
+            ;;
+        --dtr-pulse-duration)
+            COMPREPLY=( $(compgen -W "10 50 100 500" -- ${cur}) )
             return 0
             ;;
         -n | --no-autoconnect)

--- a/src/configfile.c
+++ b/src/configfile.c
@@ -124,6 +124,10 @@ static int data_handler(void *user, const char *section, const char *name,
         {
             option.output_delay = atoi(value);
         }
+        else if (!strcmp(name, "dtr-pulse-duration"))
+        {
+            option.dtr_pulse_duration = atoi(value);
+        }
         else if (!strcmp(name, "no-autoconnect"))
         {
             if (!strcmp(value, "enable"))

--- a/src/options.c
+++ b/src/options.c
@@ -42,6 +42,7 @@ enum opt_t
     OPT_TIMESTAMP_FORMAT,
     OPT_LOG_FILE,
     OPT_LOG_STRIP,
+    OPT_DTR_PULSE_DURATION,
 };
 
 /* Default options */
@@ -54,6 +55,7 @@ struct option_t option =
     .stopbits = 1,
     .parity = "none",
     .output_delay = 0,
+    .dtr_pulse_duration = 100,
     .no_autoconnect = false,
     .log = false,
     .log_filename = NULL,
@@ -79,6 +81,7 @@ void print_help(char *argv[])
     printf("  -s, --stopbits 1|2               Stop bits (default: 1)\n");
     printf("  -p, --parity odd|even|none       Parity (default: none)\n");
     printf("  -o, --output-delay <ms>          Output delay (default: 0)\n");
+    printf("      --dtr-pulse-duration <ms>    DTR pulse duration (default: 100)\n");
     printf("  -n, --no-autoconnect             Disable automatic connect\n");
     printf("  -e, --local-echo                 Enable local echo\n");
     printf("  -t, --timestamp                  Enable line timestamp\n");
@@ -169,6 +172,7 @@ void options_print()
     tio_printf(" Local echo: %s", option.local_echo ? "enabled" : "disabled");
     tio_printf(" Timestamp: %s", timestamp_state_to_string(option.timestamp));
     tio_printf(" Output delay: %d", option.output_delay);
+    tio_printf(" DTR pulse duration: %d", option.dtr_pulse_duration);
     tio_printf(" Auto connect: %s", option.no_autoconnect ? "disabled" : "enabled");
     if (option.map[0] != 0)
         tio_printf(" Map flags: %s", option.map);
@@ -198,6 +202,7 @@ void options_parse(int argc, char *argv[])
             {"stopbits",         required_argument, 0, 's'                  },
             {"parity",           required_argument, 0, 'p'                  },
             {"output-delay",     required_argument, 0, 'o'                  },
+            {"dtr-pulse-duration",   required_argument, 0, OPT_DTR_PULSE_DURATION   },
             {"no-autoconnect",   no_argument,       0, 'n'                  },
             {"local-echo",       no_argument,       0, 'e'                  },
             {"timestamp",        no_argument,       0, 't'                  },
@@ -259,6 +264,10 @@ void options_parse(int argc, char *argv[])
 
             case 'o':
                 option.output_delay = string_to_long(optarg);
+                break;
+
+            case OPT_DTR_PULSE_DURATION:
+                option.dtr_pulse_duration = string_to_long(optarg);
                 break;
 
             case 'n':

--- a/src/options.h
+++ b/src/options.h
@@ -48,6 +48,7 @@ struct option_t
     int stopbits;
     char *parity;
     int output_delay;
+    int dtr_pulse_duration;
     bool no_autoconnect;
     bool log;
     bool log_strip;

--- a/src/tty.c
+++ b/src/tty.c
@@ -256,6 +256,7 @@ void handle_command_sequence(char input_char, char previous_char, char *output_c
                 tio_printf(" ctrl-t b   Send break");
                 tio_printf(" ctrl-t c   Show configuration");
                 tio_printf(" ctrl-t d   Toggle DTR line");
+                tio_printf(" ctrl-t D   Pulse DTR line");
                 tio_printf(" ctrl-t e   Toggle local echo mode");
                 tio_printf(" ctrl-t h   Toggle hexadecimal mode");
                 tio_printf(" ctrl-t l   Clear screen");
@@ -283,6 +284,12 @@ void handle_command_sequence(char input_char, char previous_char, char *output_c
                 tio_printf(" RI : %s", (state & TIOCM_RI) ? "HIGH" : "LOW");
                 break;
             case KEY_D:
+                toggle_line("DTR", TIOCM_DTR);
+                break;
+
+            case KEY_SHIFT_D:
+                toggle_line("DTR", TIOCM_DTR);
+                delay(option.dtr_pulse_duration);
                 toggle_line("DTR", TIOCM_DTR);
                 break;
 

--- a/src/tty.h
+++ b/src/tty.h
@@ -36,6 +36,7 @@
 #define KEY_CTRL_T 0x14
 #define KEY_V 0x76
 #define KEY_D 0x64
+#define KEY_SHIFT_D 0x44
 #define KEY_R 0x72
 #define KEY_SHIFT_L 0x4C
 


### PR DESCRIPTION
MCUs like the ESP32 can be reset if the serial port DTR line is
pulsed for a short time.  You could just type CTRL-T d CTRL-T d
but that's a little awkward since you have to lift your finger
off the CTRL key to type the ds.  Now you can just type CTRL-T D.

* Added new command "D" to pulse the DTR line.  I.E.  Toggle its
  state twice with a configurable duration between toggles.

* Added new config/command line option "--dtr-pulse-duration" to set
  the duration between the DTR state toggles.  The default is
  100ms.

Resolves #153 