### PR TITLE
Additional commands: EOL delay, lower to upper translation, added mar…

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ when used in combination with [tmux](https://tmux.github.io).
  * Local echo support
  * Remap special characters (nl, cr-nl, bs, etc.)
  * Line timestamps
- * Support for delayed output
+ * Support for delayed output per transmitted character
+ * Support for delayed output per line
+ * Support for translation of lower case to upper case
  * Hexadecimal mode
  * Log to file
  * Autogeneration of log filename
@@ -66,6 +68,13 @@ The command-line interface is straightforward as reflected in the output from
       -s, --stopbits 1|2               Stop bits (default: 1)
       -p, --parity odd|even|none       Parity (default: none)
       -o, --output-delay <ms>          Character output delay (default: 0)
+      -O, --eol-delay <ms>             EOL output delay (default: 0)
+          --dtr-pulse-duration <ms>    DTR pulse duration (default: 100)
+      -n, --no-autoconnect             Disable automatic connect
+      -e, --local-echo                 Enable local echo
+      -t, --timestamp                  Enable line timestamp
+          --timestamp-format <format>  Set timestamp format (default: 24hour)
+      -L, --list-devices               List available serial devices
           --dtr-pulse-duration <ms>    DTR pulse duration (default: 100)
       -n, --no-autoconnect             Disable automatic connect
       -e, --local-echo                 Enable local echo
@@ -79,6 +88,7 @@ The command-line interface is straightforward as reflected in the output from
       -c, --color 0..255|none|list     Colorize tio text (default: 15)
       -S, --socket <socket>            Redirect I/O to file or network socket
       -x, --hexadecimal                Enable hexadecimal mode
+      -U, --upper                      Enable translation of lower case to upper
       -v, --version                    Display version
       -h, --help                       Display help
 
@@ -137,6 +147,7 @@ ctrl-t ? to list the available key commands.
 [20:19:12.041]  ctrl-t s   Show statistics
 [20:19:12.041]  ctrl-t t   Send ctrl-t key code
 [20:19:12.041]  ctrl-t T   Toggle line timestamp mode
+[20:19:12.041]  ctrl-t U   Toggle lower case alpha to upper case
 [20:19:12.041]  ctrl-t v   Show version
 ```
 

--- a/man/tio.1.in
+++ b/man/tio.1.in
@@ -34,7 +34,7 @@ Set flow control (default: none).
 
 Set stop bits (default: 1).
 .TP
-.BR \-p ", " "\-\-parity odd" | even | none
+.BR \-p ", " "\-\-parity odd" | even | none | mark
 
 Set parity (default: none).
 .TP
@@ -42,6 +42,15 @@ Set parity (default: none).
 
 Set output delay [ms] inserted between each sent character (default: 0).
 
+.TP
+.BR \-O ", " "\-\-eol\-delay " \fI<ms>
+
+Set EOL delay [ms] inserted between each sent line (default: 0).
+
+.TP
+.BR \-U ", " \-\-upcase"
+
+Convert any entered lower case alpha to upper case (default: disabled)
 .TP
 .BR "    \-\-dtr\-pulse\-duration " \fI<ms>
 
@@ -209,6 +218,8 @@ Toggle DTR
 Pulse DTR
 .IP "\fBctrl-t r"
 Toggle RTS
+.IP "\fBctrl-t U"
+Toggle upcase
 .IP "\fBctrl-t v"
 Show version
 
@@ -262,6 +273,10 @@ Set stop bits
 Set parity
 .IP "\fBoutput-delay"
 Set output delay
+.IP "\fBeol-delay"
+Set EOL delay
+.IP "\fBupcase"
+Set translation of alpha from lower to upper case
 .IP "\fBdtr-pulse-duration"
 Set DTR pulse duration
 .IP "\fBno-autoconnect"

--- a/src/configfile.c
+++ b/src/configfile.c
@@ -131,7 +131,7 @@ static int data_handler(void *user, const char *section, const char *name,
         else if ( !strcmp(name, "upcase"))
         {
             option.upcase = true;
-	}
+        }
         else if (!strcmp(name, "dtr-pulse-duration"))
         {
             option.dtr_pulse_duration = atoi(value);

--- a/src/configfile.c
+++ b/src/configfile.c
@@ -124,6 +124,14 @@ static int data_handler(void *user, const char *section, const char *name,
         {
             option.output_delay = atoi(value);
         }
+        else if (!strcmp(name, "eol-delay"))
+        {
+            option.eol_delay = atoi(value);
+        }
+	else if ( !strcmp(name, "upcase"))
+	{
+	    option.upcase = true;
+	}
         else if (!strcmp(name, "dtr-pulse-duration"))
         {
             option.dtr_pulse_duration = atoi(value);

--- a/src/configfile.c
+++ b/src/configfile.c
@@ -128,9 +128,9 @@ static int data_handler(void *user, const char *section, const char *name,
         {
             option.eol_delay = atoi(value);
         }
-	else if ( !strcmp(name, "upcase"))
-	{
-	    option.upcase = true;
+        else if ( !strcmp(name, "upcase"))
+        {
+            option.upcase = true;
 	}
         else if (!strcmp(name, "dtr-pulse-duration"))
         {

--- a/src/options.c
+++ b/src/options.c
@@ -56,6 +56,8 @@ struct option_t option =
     .parity = "none",
     .output_delay = 0,
     .dtr_pulse_duration = 100,
+    .eol_delay = 0,
+    .upcase = false,
     .no_autoconnect = false,
     .log = false,
     .log_filename = NULL,
@@ -79,8 +81,9 @@ void print_help(char *argv[])
     printf("  -d, --databits 5|6|7|8           Data bits (default: 8)\n");
     printf("  -f, --flow hard|soft|none        Flow control (default: none)\n");
     printf("  -s, --stopbits 1|2               Stop bits (default: 1)\n");
-    printf("  -p, --parity odd|even|none       Parity (default: none)\n");
+    printf("  -p, --parity odd|even|none|mark  Parity (default: none)\n");
     printf("  -o, --output-delay <ms>          Output delay (default: 0)\n");
+    printf("  -O, --eol-delay <ms>             EOL output delay (default: 0)\n");
     printf("      --dtr-pulse-duration <ms>    DTR pulse duration (default: 100)\n");
     printf("  -n, --no-autoconnect             Disable automatic connect\n");
     printf("  -e, --local-echo                 Enable local echo\n");
@@ -94,6 +97,7 @@ void print_help(char *argv[])
     printf("  -c, --color 0..255|none|list     Colorize tio text (default: 15)\n");
     printf("  -S, --socket <socket>            Redirect I/O to file or network socket\n");
     printf("  -x, --hexadecimal                Enable hexadecimal mode\n");
+    printf("  -U, --upcase		       Translate lower case alpha to upper case\n");
     printf("  -v, --version                    Display version\n");
     printf("  -h, --help                       Display help\n");
     printf("\n");
@@ -172,6 +176,8 @@ void options_print()
     tio_printf(" Local echo: %s", option.local_echo ? "enabled" : "disabled");
     tio_printf(" Timestamp: %s", timestamp_state_to_string(option.timestamp));
     tio_printf(" Output delay: %d", option.output_delay);
+    tio_printf(" EOL delay: %d", option.eol_delay);
+    tio_printf(" Upcase: %s", option.upcase ? "enabled" : "disabled");
     tio_printf(" DTR pulse duration: %d", option.dtr_pulse_duration);
     tio_printf(" Auto connect: %s", option.no_autoconnect ? "disabled" : "enabled");
     if (option.map[0] != 0)
@@ -202,6 +208,8 @@ void options_parse(int argc, char *argv[])
             {"stopbits",         required_argument, 0, 's'                  },
             {"parity",           required_argument, 0, 'p'                  },
             {"output-delay",     required_argument, 0, 'o'                  },
+	    {"eol-delay",        required_argument, 0, 'O'                  },
+	    {"upcase",           no_argument,       0, 'U'                  },
             {"dtr-pulse-duration",   required_argument, 0, OPT_DTR_PULSE_DURATION   },
             {"no-autoconnect",   no_argument,       0, 'n'                  },
             {"local-echo",       no_argument,       0, 'e'                  },
@@ -224,7 +232,7 @@ void options_parse(int argc, char *argv[])
         int option_index = 0;
 
         /* Parse argument using getopt_long */
-        c = getopt_long(argc, argv, "b:d:f:s:p:o:netLlS:m:c:xvh", long_options, &option_index);
+        c = getopt_long(argc, argv, "b:d:f:s:p:o:O:UnetLlS:m:c:xvh", long_options, &option_index);
 
         /* Detect the end of the options */
         if (c == -1)
@@ -265,6 +273,10 @@ void options_parse(int argc, char *argv[])
             case 'o':
                 option.output_delay = string_to_long(optarg);
                 break;
+
+	    case 'O':
+		option.eol_delay = string_to_long(optarg);
+		break;
 
             case OPT_DTR_PULSE_DURATION:
                 option.dtr_pulse_duration = string_to_long(optarg);
@@ -340,6 +352,10 @@ void options_parse(int argc, char *argv[])
             case 'x':
                 option.hex_mode = true;
                 break;
+
+	    case 'U':
+		option.upcase = true;
+		break;
 
             case 'v':
                 printf("tio v%s\n", VERSION);

--- a/src/options.c
+++ b/src/options.c
@@ -97,7 +97,7 @@ void print_help(char *argv[])
     printf("  -c, --color 0..255|none|list     Colorize tio text (default: 15)\n");
     printf("  -S, --socket <socket>            Redirect I/O to file or network socket\n");
     printf("  -x, --hexadecimal                Enable hexadecimal mode\n");
-    printf("  -U, --upcase		       Translate lower case alpha to upper case\n");
+    printf("  -U, --upcase                     Translate lower case alpha to upper case\n");
     printf("  -v, --version                    Display version\n");
     printf("  -h, --help                       Display help\n");
     printf("\n");
@@ -208,8 +208,8 @@ void options_parse(int argc, char *argv[])
             {"stopbits",         required_argument, 0, 's'                  },
             {"parity",           required_argument, 0, 'p'                  },
             {"output-delay",     required_argument, 0, 'o'                  },
-	    {"eol-delay",        required_argument, 0, 'O'                  },
-	    {"upcase",           no_argument,       0, 'U'                  },
+            {"eol-delay",        required_argument, 0, 'O'                  },
+            {"upcase",           no_argument,       0, 'U'                  },
             {"dtr-pulse-duration",   required_argument, 0, OPT_DTR_PULSE_DURATION   },
             {"no-autoconnect",   no_argument,       0, 'n'                  },
             {"local-echo",       no_argument,       0, 'e'                  },
@@ -274,9 +274,9 @@ void options_parse(int argc, char *argv[])
                 option.output_delay = string_to_long(optarg);
                 break;
 
-	    case 'O':
-		option.eol_delay = string_to_long(optarg);
-		break;
+            case 'O':
+                option.eol_delay = string_to_long(optarg);
+                break;
 
             case OPT_DTR_PULSE_DURATION:
                 option.dtr_pulse_duration = string_to_long(optarg);
@@ -353,9 +353,9 @@ void options_parse(int argc, char *argv[])
                 option.hex_mode = true;
                 break;
 
-	    case 'U':
-		option.upcase = true;
-		break;
+            case 'U':
+                option.upcase = true;
+                break;
 
             case 'v':
                 printf("tio v%s\n", VERSION);
@@ -384,7 +384,7 @@ void options_parse(int argc, char *argv[])
 
     /* Assume first non-option is the tty device name */
     if (strcmp(option.tty_device, ""))
-	    optind++;
+            optind++;
     else if (optind < argc)
         option.tty_device = argv[optind++];
 

--- a/src/options.h
+++ b/src/options.h
@@ -49,6 +49,8 @@ struct option_t
     char *parity;
     int output_delay;
     int dtr_pulse_duration;
+    int eol_delay;
+    bool upcase;
     bool no_autoconnect;
     bool log;
     bool log_strip;

--- a/src/tty.c
+++ b/src/tty.c
@@ -152,11 +152,11 @@ ssize_t tty_write(int fd, const void *buffer, size_t count)
         // Write byte by byte with output delay
         for (size_t i=0; i<count; i++)
         {
-	    // convert alpha to upper case
-	    if ( option.upcase )
-	    {
-		*(unsigned char*)buffer = toupper(*(unsigned char*)buffer);
-	    }
+            // convert alpha to upper case
+            if ( option.upcase )
+            {
+                *(unsigned char*)buffer = toupper(*(unsigned char*)buffer);
+            }
             ssize_t retval = write(fd, buffer, 1);
             if (retval < 0)
             {
@@ -165,15 +165,15 @@ ssize_t tty_write(int fd, const void *buffer, size_t count)
                 break;
             }
             bytes_written += retval;
-	    if ( option.eol_delay && *(unsigned char*)buffer == '\r' )
-	    {
-		delay( option.eol_delay );
-	    }
+            if ( option.eol_delay && *(unsigned char*)buffer == '\r' )
+            {
+                delay( option.eol_delay );
+            }
             fsync(fd);
-	    if ( option.output_delay )
-	    {
-		delay(option.output_delay);
-	    }
+            if ( option.output_delay )
+            {
+                delay(option.output_delay);
+            }
         }
     }
     else
@@ -184,14 +184,14 @@ ssize_t tty_write(int fd, const void *buffer, size_t count)
             tty_flush(fd);
         }
 
-	// convert lower case to upper case, in situ
-	if ( option.upcase )
-	{
-	    for ( size_t i = 0; i<count; i++ )
-	    {
-		*((unsigned char*)buffer+i) = toupper(*((unsigned char*)buffer+i));
-	    }
-	}
+        // convert lower case to upper case, in situ
+        if ( option.upcase )
+        {
+            for ( size_t i = 0; i<count; i++ )
+            {
+                *((unsigned char*)buffer+i) = toupper(*((unsigned char*)buffer+i));
+            }
+        }
         // Copy bytes to tty write buffer
         memcpy(tty_buffer_write_ptr, buffer, count);
         tty_buffer_write_ptr += count;
@@ -287,7 +287,7 @@ void handle_command_sequence(char input_char, char previous_char, char *output_c
                 tio_printf(" ctrl-t s   Show statistics");
                 tio_printf(" ctrl-t t   Send ctrl-t key code");
                 tio_printf(" ctrl-t T   Toggle line timestamp mode");
-		tio_printf(" ctrl-t U   Toggle upcase");
+                tio_printf(" ctrl-t U   Toggle upcase");
                 tio_printf(" ctrl-t v   Show version");
                 break;
 
@@ -397,16 +397,16 @@ void handle_command_sequence(char input_char, char previous_char, char *output_c
                 }
                 break;
 
-	    case KEY_U:
-		if ( option.upcase == true )
-		{
-		    option.upcase = false;
-		}
-		else
-		{
-		    option.upcase = true;
-		}
-		break;
+            case KEY_U:
+                if ( option.upcase == true )
+                {
+                    option.upcase = false;
+                }
+                else
+                {
+                    option.upcase = true;
+                }
+                break;
 
             case KEY_V:
                 tio_printf("tio v%s", VERSION);
@@ -631,9 +631,9 @@ void tty_configure(void)
     }
     else if ( strcmp("mark", option.parity) == 0)
     {
-	tio.c_cflag &= ~PARENB;
-	tio.c_cflag |= PARODD;
-	tio.c_cflag |= CMSPAR;
+        tio.c_cflag &= ~PARENB;
+        tio.c_cflag |= PARODD;
+        tio.c_cflag |= CMSPAR;
     }
     else
     {

--- a/src/tty.c
+++ b/src/tty.c
@@ -24,6 +24,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
+#include <ctype.h>
 #include <stdlib.h>
 #include <limits.h>
 #include <sys/types.h>
@@ -146,11 +147,16 @@ ssize_t tty_write(int fd, const void *buffer, size_t count)
 {
     ssize_t bytes_written = 0;
 
-    if (option.output_delay)
+    if (option.output_delay || option.eol_delay )
     {
         // Write byte by byte with output delay
         for (size_t i=0; i<count; i++)
         {
+	    // convert alpha to upper case
+	    if ( option.upcase )
+	    {
+		*(unsigned char*)buffer = toupper(*(unsigned char*)buffer);
+	    }
             ssize_t retval = write(fd, buffer, 1);
             if (retval < 0)
             {
@@ -159,8 +165,15 @@ ssize_t tty_write(int fd, const void *buffer, size_t count)
                 break;
             }
             bytes_written += retval;
+	    if ( option.eol_delay && *(unsigned char*)buffer == '\r' )
+	    {
+		delay( option.eol_delay );
+	    }
             fsync(fd);
-            delay(option.output_delay);
+	    if ( option.output_delay )
+	    {
+		delay(option.output_delay);
+	    }
         }
     }
     else
@@ -171,6 +184,14 @@ ssize_t tty_write(int fd, const void *buffer, size_t count)
             tty_flush(fd);
         }
 
+	// convert lower case to upper case, in situ
+	if ( option.upcase )
+	{
+	    for ( size_t i = 0; i<count; i++ )
+	    {
+		*((unsigned char*)buffer+i) = toupper(*((unsigned char*)buffer+i));
+	    }
+	}
         // Copy bytes to tty write buffer
         memcpy(tty_buffer_write_ptr, buffer, count);
         tty_buffer_write_ptr += count;
@@ -266,6 +287,7 @@ void handle_command_sequence(char input_char, char previous_char, char *output_c
                 tio_printf(" ctrl-t s   Show statistics");
                 tio_printf(" ctrl-t t   Send ctrl-t key code");
                 tio_printf(" ctrl-t T   Toggle line timestamp mode");
+		tio_printf(" ctrl-t U   Toggle upcase");
                 tio_printf(" ctrl-t v   Show version");
                 break;
 
@@ -374,6 +396,17 @@ void handle_command_sequence(char input_char, char previous_char, char *output_c
                         break;
                 }
                 break;
+
+	    case KEY_U:
+		if ( option.upcase == true )
+		{
+		    option.upcase = false;
+		}
+		else
+		{
+		    option.upcase = true;
+		}
+		break;
 
             case KEY_V:
                 tio_printf("tio v%s", VERSION);
@@ -595,6 +628,12 @@ void tty_configure(void)
     else if (strcmp("none", option.parity) == 0)
     {
         tio.c_cflag &= ~PARENB;
+    }
+    else if ( strcmp("mark", option.parity) == 0)
+    {
+	tio.c_cflag &= ~PARENB;
+	tio.c_cflag |= PARODD;
+	tio.c_cflag |= CMSPAR;
     }
     else
     {

--- a/src/tty.h
+++ b/src/tty.h
@@ -34,6 +34,7 @@
 #define KEY_T 0x74
 #define KEY_SHIFT_T 0x54
 #define KEY_CTRL_T 0x14
+#define KEY_U 0x55
 #define KEY_V 0x76
 #define KEY_D 0x64
 #define KEY_SHIFT_D 0x44

--- a/token.txt
+++ b/token.txt
@@ -1,2 +1,0 @@
-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
-

--- a/token.txt
+++ b/token.txt
@@ -1,0 +1,2 @@
+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
+


### PR DESCRIPTION
…k parity

Added command line options:
-O, --eol-delay to have a separate delay for end of line
-U, --upper to enable translation of lower case alpha to upper case

Added ability to set mark parity.
Added ctrl-t U key sequence to allow enable/disable lower case alpha to
upper case during a session.
Updated Man page with command line options, ctrl-t sequences and
configuration file options.
Updated README.md, with above information.