### PR TITLE
Ignore SIGPIPE signals

### DIFF
--- a/src/signals.c
+++ b/src/signals.c
@@ -47,4 +47,5 @@ void signal_handlers_install(void)
 {
     signal(SIGHUP, signal_handler);
     signal(SIGINT, signal_handler);
+    signal(SIGPIPE, SIG_IGN);
 }


### PR DESCRIPTION
If the remote end of a socket is closed between when an input character
is received from the serial port and when it is written to the socket,
tio will receive a SIGPIPE signal when writing the character to the
socket, which will terminate the program. To prevent this, ignore the
signal, which will cause write(2) to return -EPIPE, causing tio to close
the socket.