### PR TITLE
Better error checking in config file, rename the file

### DIFF
--- a/man/tio.1.in
+++ b/man/tio.1.in
@@ -332,11 +332,9 @@ the configuration file first found in the following locations in the order
 listed:
 
 .PP
-.I $XDG_CONFIG_HOME/tio/tiorc
+.I $XDG_CONFIG_HOME/tio/config
 .PP
-.I $HOME/.config/tio/tiorc
-.PP
-.I $HOME/.tiorc
+.I $HOME/.config/tio/config
 
 .PP
 Labels can be used to group settings into named sub-configurations which can be


### PR DESCRIPTION
Accept "true", "enable", "on", "yes", "1" as true values, their counterparts as false ones. Check integer values for errors and range. Warn about ignored (e.g. misspelled) options.

Check getenv() return value for NULL.

Rename "tiorc" to "config", as it's a static INI file, not an executable "run commands".