### PR TITLE
Support input mapping modes for sockets

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -33,6 +33,7 @@
 #include "socket.h"
 #include "options.h"
 #include "print.h"
+#include "tty.h"
 
 #define MAX_SOCKET_CLIENTS 16
 #define SOCKET_PORT_DEFAULT 3333
@@ -41,9 +42,6 @@ static int sockfd;
 static int clientfds[MAX_SOCKET_CLIENTS];
 static int socket_family = AF_UNSPEC;
 static int port_number = SOCKET_PORT_DEFAULT;
-bool map_i_nl_cr = false;
-bool map_i_cr_nl = false;
-bool map_ign_cr = false;
 
 static const char *socket_filename(void)
 {

--- a/src/socket.c
+++ b/src/socket.c
@@ -41,9 +41,9 @@ static int sockfd;
 static int clientfds[MAX_SOCKET_CLIENTS];
 static int socket_family = AF_UNSPEC;
 static int port_number = SOCKET_PORT_DEFAULT;
-static bool map_i_nl_cr = false;
-static bool map_i_cr_nl = false;
-static bool map_ign_cr = false;
+bool map_i_nl_cr = false;
+bool map_i_cr_nl = false;
+bool map_ign_cr = false;
 
 static const char *socket_filename(void)
 {
@@ -126,9 +126,6 @@ void socket_configure(void)
     struct sockaddr_in6 sockaddr_inet6 = {};
     struct sockaddr *sockaddr_p;
     socklen_t socklen;
-    bool token_found = true;
-    char *token = NULL;
-    char *buffer;
 
     /* Parse socket string */
 
@@ -180,41 +177,6 @@ void socket_configure(void)
         tio_error_printf("%s: Invalid socket scheme, must be prefixed with 'unix:', 'inet:', or 'inet6:'", option.socket);
         exit(EXIT_FAILURE);
     }
-
-    /* Configure any specified input mappings */
-    buffer = strdup(option.map);
-    while (token_found == true)
-    {
-        if (token == NULL)
-        {
-            token = strtok(buffer,",");
-        }
-        else
-        {
-            token = strtok(NULL, ",");
-        }
-
-        if (token != NULL)
-        {
-            if (strcmp(token,"INLCR") == 0)
-            {
-                map_i_nl_cr = true;
-            }
-            else if (strcmp(token,"IGNCR") == 0)
-            {
-                map_ign_cr = true;
-            }
-            else if (strcmp(token,"ICRNL") == 0)
-            {
-                map_i_cr_nl = true;
-            }
-        }
-        else
-        {
-            token_found = false;
-        }
-    }
-    free(buffer);
 
     /* Configure socket */
 

--- a/src/socket.c
+++ b/src/socket.c
@@ -41,6 +41,9 @@ static int sockfd;
 static int clientfds[MAX_SOCKET_CLIENTS];
 static int socket_family = AF_UNSPEC;
 static int port_number = SOCKET_PORT_DEFAULT;
+static bool map_i_nl_cr = false;
+static bool map_i_cr_nl = false;
+static bool map_ign_cr = false;
 
 static const char *socket_filename(void)
 {
@@ -123,6 +126,9 @@ void socket_configure(void)
     struct sockaddr_in6 sockaddr_inet6 = {};
     struct sockaddr *sockaddr_p;
     socklen_t socklen;
+    bool token_found = true;
+    char *token = NULL;
+    char *buffer;
 
     /* Parse socket string */
 
@@ -174,6 +180,41 @@ void socket_configure(void)
         tio_error_printf("%s: Invalid socket scheme, must be prefixed with 'unix:', 'inet:', or 'inet6:'", option.socket);
         exit(EXIT_FAILURE);
     }
+
+    /* Configure any specified input mappings */
+    buffer = strdup(option.map);
+    while (token_found == true)
+    {
+        if (token == NULL)
+        {
+            token = strtok(buffer,",");
+        }
+        else
+        {
+            token = strtok(NULL, ",");
+        }
+
+        if (token != NULL)
+        {
+            if (strcmp(token,"INLCR") == 0)
+            {
+                map_i_nl_cr = true;
+            }
+            else if (strcmp(token,"IGNCR") == 0)
+            {
+                map_ign_cr = true;
+            }
+            else if (strcmp(token,"ICRNL") == 0)
+            {
+                map_i_cr_nl = true;
+            }
+        }
+        else
+        {
+            token_found = false;
+        }
+    }
+    free(buffer);
 
     /* Configure socket */
 
@@ -340,10 +381,25 @@ bool socket_handle_input(fd_set *rdfs, char *output_char)
                 clientfds[i] = -1;
                 continue;
             }
-            /* match the behavior of a terminal in raw mode */
-            if (*output_char == '\n')
+
+            /* If INLCR is set, a received NL character shall be translated into a CR character */
+            if (*output_char == '\n' && map_i_nl_cr)
             {
                 *output_char = '\r';
+            }
+            else if (*output_char == '\r')
+            {
+                /* If IGNCR is set, a received CR character shall be ignored (not read). */
+                if (map_ign_cr)
+                {
+                    return false;
+                }
+
+                /* If IGNCR is not set and ICRNL is set, a received CR character shall be translated into an NL character. */
+                if (map_i_cr_nl)
+                {
+                    *output_char = '\n';
+                }
             }
             return true;
         }

--- a/src/socket.h
+++ b/src/socket.h
@@ -25,10 +25,6 @@
 #include <stdbool.h>
 #include <sys/select.h>
 
-extern bool map_i_nl_cr;
-extern bool map_i_cr_nl;
-extern bool map_ign_cr;
-
 void socket_configure(void);
 void socket_write(char input_char);
 int socket_add_fds(fd_set *fds, bool connected);

--- a/src/socket.h
+++ b/src/socket.h
@@ -25,6 +25,10 @@
 #include <stdbool.h>
 #include <sys/select.h>
 
+extern bool map_i_nl_cr;
+extern bool map_i_cr_nl;
+extern bool map_ign_cr;
+
 void socket_configure(void);
 void socket_write(char input_char);
 int socket_add_fds(fd_set *fds, bool connected);

--- a/src/tty.c
+++ b/src/tty.c
@@ -987,14 +987,17 @@ void tty_configure(void)
             if (strcmp(token,"INLCR") == 0)
             {
                 tio.c_iflag |= INLCR;
+                map_i_nl_cr = true;
             }
             else if (strcmp(token,"IGNCR") == 0)
             {
                 tio.c_iflag |= IGNCR;
+                map_ign_cr = true;
             }
             else if (strcmp(token,"ICRNL") == 0)
             {
                 tio.c_iflag |= ICRNL;
+                map_i_cr_nl = true;
             }
             else if (strcmp(token,"OCRNL") == 0)
             {

--- a/src/tty.c
+++ b/src/tty.c
@@ -129,6 +129,9 @@ const char random_array[] =
 };
 
 bool interactive_mode = true;
+bool map_i_nl_cr = false;
+bool map_i_cr_nl = false;
+bool map_ign_cr = false;
 
 static struct termios tio, tio_old, stdout_new, stdout_old, stdin_new, stdin_old;
 static unsigned long rx_total = 0, tx_total = 0;

--- a/src/tty.h
+++ b/src/tty.h
@@ -24,6 +24,9 @@
 #include <stdbool.h>
 
 extern bool interactive_mode;
+extern bool map_i_nl_cr;
+extern bool map_i_cr_nl;
+extern bool map_ign_cr;
 
 void stdout_configure(void);
 void stdin_configure(void);


### PR DESCRIPTION
I noticed NL characters were getting mapped to CR when I was using serial mode. For my use case, I need mapping disabled.

I saw this in the [TODOs](https://github.com/tio/tio/blob/master/TODO): "Mapping flags INLCR, IGNCR, ICRNL needs implementation for socket mode". This is my attempt at that task. I based the implementation on these [docs](https://pubs.opengroup.org/onlinepubs/9699919799.2016edition/basedefs/V1_chap11.html#tag_11).

Couple things to callout:
1. Although the mapping flags seems to be the most intuitive, this is a breaking change for anyone relying on the existing default socket behavior.
2. Option parsing logic is duplicated. One alternative is passing in the mapping flags from tty.c. But I'm not a C developer, so I just went with the simplest approach.

I'm open to whatever direction, I just need some way to preserve original input while using sockets.

PS: Thank you for tio! I'm using it for an experimental project and it's saved me quite a bit of time.