### PR TITLE
Ignore EINTR error.

### DIFF
--- a/src/tty.c
+++ b/src/tty.c
@@ -299,6 +299,11 @@ void *tty_stdin_input_thread(void *arg)
         byte_count = read(STDIN_FILENO, input_buffer, BUFSIZ);
         if (byte_count < 0)
         {
+            /* No error actually occurred */
+            if (errno == EINTR)
+            {
+                continue;
+            }
             tio_warning_printf("Could not read from stdin (%s)", strerror(errno));
         }
         else if (byte_count == 0)


### PR DESCRIPTION
If `tio` is launched with Windows Terminal, following error will spam when resizing terminal window:
```
[22:31:21.594] tio v2.6
[22:31:21.597] Press ctrl-t q to quit
[22:31:21.608] Warning: Could not open tty device (No such file or directory)
[22:31:21.608] Waiting for tty device..
[22:31:23.621] Warning: Could not read from stdin (Interrupted system call)
[22:31:23.621] Warning: Could not write to pipe (Bad address)
[22:31:23.635] Warning: Could not read from stdin (Interrupted system call)
[22:31:23.635] Warning: Could not write to pipe (Bad address)
[22:31:23.663] Warning: Could not read from stdin (Interrupted system call)
[22:31:23.663] Warning: Could not write to pipe (Bad address)
[22:31:23.677] Warning: Could not read from stdin (Interrupted system call)
[22:31:23.677] Warning: Could not write to pipe (Bad address)
[22:31:23.690] Warning: Could not read from stdin (Interrupted system call)
```

AS I know `EINTR` means no error actually occurred, it's just reported when the system call was interrupted and the system isn't able to resume the system call automatically.