### PR TITLE
Add map FF to ESC-c on input

### DIFF
--- a/man/tio.1.in
+++ b/man/tio.1.in
@@ -163,6 +163,8 @@ flags are supported:
 Map CR to NL on input (unless IGNCR is set)
 .IP "\fBIGNCR"
 Ignore CR on input
+.IP "\fBIFFESCC"
+Map FF to ESC-c on input
 .IP "\fBINLCR"
 Map NL to CR on input
 .IP "\fBINLCRNL"

--- a/man/tio.1.txt
+++ b/man/tio.1.txt
@@ -124,6 +124,8 @@ OPTIONS
 
               IGNCR       Ignore CR on input
 
+              IFFESCC     Map FF to ESC-c on input
+
               INLCR       Map NL to CR on input
 
               INLCRNL     Map NL to CR-NL on input

--- a/src/bash-completion/tio.in
+++ b/src/bash-completion/tio.in
@@ -100,7 +100,7 @@ _tio()
             return 0
             ;;
         -m | --map)
-            COMPREPLY=( $(compgen -W "ICRNL IGNCR INLCR INLCRNL OCRNL ODELBS ONLCRNL MSB2LSB" -- ${cur}) )
+            COMPREPLY=( $(compgen -W "ICRNL IGNCR INLCR IFFESCC INLCRNL OCRNL ODELBS ONLCRNL MSB2LSB" -- ${cur}) )
             return 0
             ;;
         -t | --timestamp)

--- a/src/tty.c
+++ b/src/tty.c
@@ -145,6 +145,7 @@ static bool connected = false;
 static bool standard_baudrate = true;
 static void (*print)(char c);
 static int fd;
+static bool map_i_ff_escc = false;
 static bool map_i_nl_crnl = false;
 static bool map_o_cr_nl = false;
 static bool map_o_nl_crnl = false;
@@ -1070,6 +1071,10 @@ void tty_configure(void)
             {
                 map_o_del_bs = true;
             }
+            else if (strcmp(token,"IFFESCC") == 0)
+            {
+                map_i_ff_escc = true;
+            }
             else if (strcmp(token,"INLCRNL") == 0)
             {
                 map_i_nl_crnl = true;
@@ -1462,6 +1467,11 @@ int tty_connect(void)
                         {
                             next_timestamp = true;
                         }
+                    }
+                    else if ((input_char == '\f') && (map_i_ff_escc) && (!map_o_msblsb))
+                    {
+                        print('\e');
+                        print('c');
                     }
                     else
                     {


### PR DESCRIPTION
Added map of form feed to ESC-c on input for terminals that do not clear screen on ^L but do on ESC-c.