### PR TITLE
Check return values of sscanf()

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -163,7 +163,11 @@ void line_pulse_duration_option_parse(const char *arg)
         {
             char keyname[11];
             unsigned int value;
-            sscanf(token, "%10[^=]=%d", keyname, &value);
+
+            if (sscanf(token, "%10[^=]=%d", keyname, &value) != 2)
+            {
+                token_found = false;
+            }
 
             if (!strcmp(keyname, "DTR"))
             {

--- a/src/rs485.c
+++ b/src/rs485.c
@@ -57,7 +57,11 @@ void rs485_parse_config(const char *arg)
         {
             char keyname[31];
             unsigned int value;
-            sscanf(token, "%30[^=]=%d", keyname, &value);
+
+            if (sscanf(token, "%30[^=]=%d", keyname, &value) != 2)
+            {
+                token_found = false;
+            }
 
             if (!strcmp(keyname, "RTS_ON_SEND"))
             {


### PR DESCRIPTION
Failing to check that a call to 'sscanf' actually writes to an output variable can lead to unexpected behavior at reading time.