### PR TITLE
Add Xmodem-CRC support.

### DIFF
--- a/man/tio.1.in
+++ b/man/tio.1.in
@@ -345,7 +345,9 @@ Toggle conversion to uppercase on output
 .IP "\fBctrl-t v"
 Show version
 .IP "\fBctrl-t x"
-Send a file using the XMODEM protocol (prompts for file name)
+Send a file using the XMODEM-1K protocol (prompts for file name)
+.IP "\fBctrl-t X"
+Send a file using the XMODEM-CRC protocol (prompts for file name)
 .IP "\fBctrl-t y"
 Send a file using the YMODEM protocol (prompts for file name)
 .IP "\fBctrl-t ctrl-t"

--- a/man/tio.1.txt
+++ b/man/tio.1.txt
@@ -257,7 +257,9 @@ KEYS
 
        ctrl-t v        Show version
 
-       ctrl-t x        Send a file using the XMODEM protocol (prompts for file name)
+       ctrl-t x        Send a file using the XMODEM-1K protocol (prompts for file name)
+
+       ctrl-t X        Send a file using the XMODEM-CRC protocol (prompts for file name)
 
        ctrl-t y        Send a file using the YMODEM protocol (prompts for file name)
 

--- a/src/tty.c
+++ b/src/tty.c
@@ -110,6 +110,7 @@
 #define KEY_U 0x55
 #define KEY_V 0x76
 #define KEY_X 0x78
+#define KEY_SHIFT_X 0x58
 #define KEY_Y 0x79
 #define KEY_Z 0x7a
 
@@ -629,6 +630,7 @@ void handle_command_sequence(char input_char, char *output_char, bool *forward)
                 tio_printf(" ctrl-%c U       Toggle conversion to uppercase on output", option.prefix_key);
                 tio_printf(" ctrl-%c v       Show version", option.prefix_key);
                 tio_printf(" ctrl-%c x       Send file via Xmodem-1K", option.prefix_key);
+                tio_printf(" ctrl-%c X       Send file via Xmodem-CRC", option.prefix_key);
                 tio_printf(" ctrl-%c y       Send file via Ymodem", option.prefix_key);
                 tio_printf(" ctrl-%c ctrl-%c Send ctrl-%c character", option.prefix_key, option.prefix_key, option.prefix_key);
                 break;
@@ -796,7 +798,8 @@ void handle_command_sequence(char input_char, char *output_char, bool *forward)
 
             case KEY_X:
             case KEY_Y:
-                tio_printf("Send file with %cMODEM", toupper(input_char));
+            case KEY_SHIFT_X:
+                tio_printf("Send file with %s", input_char == KEY_X ?  "XMODEM-1K" : (input_char == KEY_Y ? "YMODEM" : "XMODEM-CRC"));
                 tio_printf_raw("Enter file name: ");
                 if (tio_readln()) {
                     tio_printf("Sending file '%s'  ", line);


### PR DESCRIPTION
Clarify old Xmodem option as `Xmodem-1K`, new `Xmodem-CRC` can be selected by `ctrl+t X`.

Tested on Silabs Gecko bootloader.