### PR TITLE
Update auto-login example with new expect logic

### DIFF
--- a/examples/lua/automatic-login.lua
+++ b/examples/lua/automatic-login.lua
@@ -1,28 +1,30 @@
 local logins = {
-    {
-        serialnumber = "foo",
+    ["foo"] = {
         username = "foouser",
         password = "foopass",
     },
-    {
-        serialnumber = "bar",
+    ["bar"] = {
         username = "baruser",
         password = "barpass",
     },
-    {
-        serialnumber = "baz",
+    ["baz"] = {
         username = "bazuser",
         password = "bazpass",
     },
 }
 
-for _, login in ipairs(logins) do
-    send("\n")
-    local found = expect(login.serialnumber .. ".*login:", 10)
-    if (1 == found) then
+send("\n")
+local found, match_str = expect("\\w+- login:", 10)
+if (1 == found) then
+    local model = string.match(match_str, "^%w+")
+    local login = logins[model]
+    if (nil ~= login) then
         send(login.username .. "\n")
         expect("Password:")
         send(login.password .. "\n")
-        break
+    else
+        print("\r\nDon't know login info for " .. model .. "\r\n")
     end
+else
+    print("\r\nDidn't find a login prompt\r\n")
 end


### PR DESCRIPTION
As mentioned in the discussion in https://github.com/tio/tio/pull/240, the example can be improved with the ability to return the matched text from `expect`. This updates that example to use the new functionality.