### PR TITLE
Prompt for Lua script or shell command in interactive session

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ ctrl-t ? to list the available key commands.
 [15:02:53.269]  ctrl-t p       Pulse serial port line
 [15:02:53.269]  ctrl-t q       Quit
 [15:02:53.269]  ctrl-t r       Run script
+[15:02:53.269]  ctrl-t R       Execute shell command with I/O redirected to device
 [15:02:53.269]  ctrl-t s       Show statistics
 [15:02:53.269]  ctrl-t t       Toggle line timestamp mode
 [15:02:53.269]  ctrl-t U       Toggle conversion to uppercase on output

--- a/man/tio.1.in
+++ b/man/tio.1.in
@@ -405,6 +405,8 @@ Pulse serial port line
 Quit
 .IP "\fBctrl-t r"
 Run script
+.IP "\fBctrl-t R"
+Execute shell command with I/O redirected to device
 .IP "\fBctrl-t s"
 Show TX/RX statistics
 .IP "\fBctrl-t t"

--- a/src/script.c
+++ b/src/script.c
@@ -535,7 +535,7 @@ void script_set_globals(lua_State *L)
     script_set_global(L, "YMODEM", YMODEM);
 }
 
-void script_run(int fd)
+void script_run(int fd, const char *script_filename)
 {
     lua_State *L;
 
@@ -550,7 +550,12 @@ void script_run(int fd)
     // Initialize globals
     script_set_globals(L);
 
-    if (option.script_filename != NULL)
+    if (script_filename != NULL)
+    {
+        tio_printf("Running script %s", script_filename);
+        script_file_run(L, script_filename);
+    }
+    else if (option.script_filename != NULL)
     {
         tio_printf("Running script %s", option.script_filename);
         script_file_run(L, option.script_filename);

--- a/src/script.h
+++ b/src/script.h
@@ -29,5 +29,5 @@ typedef enum
     SCRIPT_RUN_END,
 } script_run_t;
 
-void script_run(int fd);
+void script_run(int fd, const char *script_filename);
 const char *script_run_state_to_string(script_run_t state);

--- a/src/tty.c
+++ b/src/tty.c
@@ -110,6 +110,7 @@
 #define KEY_P 0x70
 #define KEY_Q 0x71
 #define KEY_R 0x72
+#define KEY_SHIFT_R 0x52
 #define KEY_S 0x73
 #define KEY_T 0x74
 #define KEY_U 0x55
@@ -765,6 +766,7 @@ void handle_command_sequence(char input_char, char *output_char, bool *forward)
                 tio_printf(" ctrl-%c p       Pulse serial port line", option.prefix_key);
                 tio_printf(" ctrl-%c q       Quit", option.prefix_key);
                 tio_printf(" ctrl-%c r       Run script", option.prefix_key);
+                tio_printf(" ctrl-%c R       Execute shell command with I/O redirected to device", option.prefix_key);
                 tio_printf(" ctrl-%c s       Show statistics", option.prefix_key);
                 tio_printf(" ctrl-%c t       Toggle line timestamp mode", option.prefix_key);
                 tio_printf(" ctrl-%c U       Toggle conversion to uppercase on output", option.prefix_key);
@@ -922,7 +924,20 @@ void handle_command_sequence(char input_char, char *output_char, bool *forward)
 
             case KEY_R:
                 /* Run script */
-                script_run(device_fd);
+                tio_printf("Run Lua script")
+                tio_printf_raw("Enter file name: ");
+                if (tio_readln())
+                    script_run(device_fd, line);
+                else
+                    script_run(device_fd, NULL);
+                break;
+
+            case KEY_SHIFT_R:
+                /* Execute shell command */
+                tio_printf("Execute shell command with I/O redirected to device");
+                tio_printf_raw("Enter command: ");
+                if (tio_readln())
+                    execute_shell_command(device_fd, line);
                 break;
 
             case KEY_S:
@@ -2281,7 +2296,7 @@ int tty_connect(void)
     /* Manage script activation */
     if (option.script_run != SCRIPT_RUN_NEVER)
     {
-        script_run(device_fd);
+        script_run(device_fd, NULL);
 
         if (option.script_run == SCRIPT_RUN_ONCE)
         {


### PR DESCRIPTION
With this changes, `ctrl-t r` prompt for script file name, and `ctrl-t R` for shell command to execute. On empty input, `ctrl-t r` runs the default script provided in options or in configuration file. This makes workflow close to TeraTerm where you can choose and run arbitrary macro files during interactive session.

By the way, what about replacing `tio_readln` with GNU readline, which adds auto-completion for file names, history, etc.?