### PR TITLE
Print correct 'Done' timestamp for X- and Y-modem transfers

### DIFF
--- a/src/script.c
+++ b/src/script.c
@@ -149,6 +149,7 @@ static int modem_send(lua_State *L)
 {
     const char *file = lua_tostring(L, 1);
     int protocol = lua_tointeger(L, 2);
+    int ret;
 
     if (file == NULL)
     {
@@ -159,18 +160,21 @@ static int modem_send(lua_State *L)
     {
         case XMODEM_1K:
             tio_printf("Sending file '%s' using XMODEM-1K", file);
-            tio_printf("%s", xymodem_send(device_fd, file, XMODEM_1K) < 0 ? "Aborted" : "Done");
+            ret = xymodem_send(device_fd, file, XMODEM_1K);
+            tio_printf("%s", ret < 0 ? "Aborted" : "Done");
             break;
 
         case XMODEM_CRC:
             tio_printf("Sending file '%s' using XMODEM-CRC", file);
-            tio_printf("%s", xymodem_send(device_fd, file, XMODEM_CRC) < 0 ? "Aborted" : "Done");
-        break;
+            ret = xymodem_send(device_fd, file, XMODEM_CRC);
+            tio_printf("%s", ret < 0 ? "Aborted" : "Done");
+            break;
 
         case YMODEM:
             tio_printf("Sending file '%s' using YMODEM", file);
-            tio_printf("%s", xymodem_send(device_fd, file, YMODEM) < 0 ? "Aborted" : "Done");
-        break;
+            ret = xymodem_send(device_fd, file, YMODEM);
+            tio_printf("%s", ret < 0 ? "Aborted" : "Done");
+            break;
     }
 
     return 0;

--- a/src/tty.c
+++ b/src/tty.c
@@ -712,9 +712,12 @@ void handle_command_sequence(char input_char, char *output_char, bool *forward)
                         tio_printf_raw("Enter file name: ");
                         if (tio_readln())
                         {
+                            int ret;
+
                             tio_printf("Sending file '%s'  ", line);
                             tio_printf("Press any key to abort transfer");
-                            tio_printf("%s", xymodem_send(device_fd, line, XMODEM_1K) < 0 ? "Aborted" : "Done");
+                            ret = xymodem_send(device_fd, line, XMODEM_1K);
+                            tio_printf("%s", ret < 0 ? "Aborted" : "Done");
                         }
                         break;
 
@@ -723,9 +726,12 @@ void handle_command_sequence(char input_char, char *output_char, bool *forward)
                         tio_printf_raw("Enter file name: ");
                         if (tio_readln())
                         {
+                            int ret;
+
                             tio_printf("Sending file '%s'  ", line);
                             tio_printf("Press any key to abort transfer");
-                            tio_printf("%s", xymodem_send(device_fd, line, XMODEM_CRC) < 0 ? "Aborted" : "Done");
+                            ret = xymodem_send(device_fd, line, XMODEM_CRC);
+                            tio_printf("%s", ret < 0 ? "Aborted" : "Done");
                         }
                         break;
 
@@ -734,9 +740,12 @@ void handle_command_sequence(char input_char, char *output_char, bool *forward)
                         tio_printf_raw("Enter file name: ");
                         if (tio_readln())
                         {
+                            int ret;
+
                             tio_printf("Ready to receiving file '%s'  ", line);
                             tio_printf("Press any key to abort transfer");
-                            tio_printf("%s", xymodem_receive(device_fd, line, XMODEM_CRC) < 0 ? "Aborted" : "Done");
+                            ret = xymodem_send(device_fd, line, XMODEM_CRC);
+                            tio_printf("%s", ret < 0 ? "Aborted" : "Done");
                         }
                         break;
 
@@ -1094,9 +1103,12 @@ void handle_command_sequence(char input_char, char *output_char, bool *forward)
                 tio_printf("Send file with YMODEM");
                 tio_printf_raw("Enter file name: ");
                 if (tio_readln()) {
+		    int ret;
+
                     tio_printf("Sending file '%s'  ", line);
                     tio_printf("Press any key to abort transfer");
-                    tio_printf("%s", xymodem_send(device_fd, line, YMODEM) < 0 ? "Aborted" : "Done");
+		    ret = xymodem_send(device_fd, line, YMODEM);
+                    tio_printf("%s", ret < 0 ? "Aborted" : "Done");
                 }
                 break;
 


### PR DESCRIPTION
Closes: #268

Call tio_printf() after completing xymodem_send().