### PR TITLE
Add lua function read_ts which emits timestamps per option.timestamp

### DIFF
--- a/examples/lua/pts.lua
+++ b/examples/lua/pts.lua
@@ -1,0 +1,13 @@
+send("\n")
+msleep(100)
+read_ts(650, 60) -- main menu
+send("S") -- S menu
+msleep(30)
+read_ts(650, 60)
+send("t") -- Parallel Value Table
+read_ts(650, 60)
+while true do
+  msleep(970)
+  send("t")
+  read_ts(650, 50) -- repeat PVT forever
+end

--- a/examples/lua/pvt.lua
+++ b/examples/lua/pvt.lua
@@ -1,0 +1,16 @@
+send("\n")
+msleep(100)
+-- read buffer with 0.5 sec delay
+read(160, 500)
+send("S")
+msleep(100)
+-- read buffer
+read(160, 500)
+-- query Parallel Value Table
+send("t")
+print(read(300, 500))
+while true do
+  sleep(1)
+  send("t")
+  print(read(300, 500))
+end

--- a/man/tio.1.txt
+++ b/man/tio.1.txt
@@ -375,6 +375,13 @@ SCRIPT API
 
              On success, returns read string as second return value.
 
+       read_ts(size, timeout)
+             Read from serial device. If timeout is 0 or not provided it will wait forever until data is ready to read.
+
+             Returns number of bytes read on success, 0 on timeout, or -1 on error.
+
+             On success, returns read string as second return value.  Additionally, emit timestamp to stdout and log file per options.timestamp and options.log.
+
        set{line=state, ...}
              Set state of one or multiple tty modem lines.
 

--- a/meson.build
+++ b/meson.build
@@ -1,12 +1,12 @@
 project('tio', 'c',
-    version : '3.8',
+    version : '3.8.1',
     license : [ 'GPL-2'],
     meson_version : '>= 0.53.2',
     default_options : [ 'warning_level=2', 'buildtype=release', 'c_std=gnu99' ]
 )
 
 # The tag date of the project_version(), update when the version bumps.
-version_date = '2024-08-31'
+version_date = '2024-10-24'
 
 # Test for dynamic baudrate configuration interface
 compiler = meson.get_compiler('c')

--- a/meson.build
+++ b/meson.build
@@ -1,12 +1,12 @@
 project('tio', 'c',
-    version : '3.8.1',
+    version : '3.8',
     license : [ 'GPL-2'],
     meson_version : '>= 0.53.2',
     default_options : [ 'warning_level=2', 'buildtype=release', 'c_std=gnu99' ]
 )
 
 # The tag date of the project_version(), update when the version bumps.
-version_date = '2024-10-24'
+version_date = '2024-08-31'
 
 # Test for dynamic baudrate configuration interface
 compiler = meson.get_compiler('c')

--- a/src/timestamp.c
+++ b/src/timestamp.c
@@ -29,8 +29,6 @@
 #include "options.h"
 #include "timestamp.h"
 
-#define TIME_STRING_SIZE_MAX 24
-
 char *timestamp_current_time(void)
 {
     static char time_string[TIME_STRING_SIZE_MAX];

--- a/src/timestamp.h
+++ b/src/timestamp.h
@@ -32,5 +32,7 @@ typedef enum
     TIMESTAMP_END,
 } timestamp_t;
 
+#define TIME_STRING_SIZE_MAX 24
+
 char *timestamp_current_time(void);
 


### PR DESCRIPTION
- add read_ts to scripts.c
- link lua function 'read_ts' to c function of same name
- use read_ts in lua scripts to emit timestamps to normal lines of input