### PR TITLE
Manpage: Fix backslash encoding

### DIFF
--- a/man/tio.1.in
+++ b/man/tio.1.in
@@ -435,7 +435,7 @@ available:
 
 .IP "\fBexpect(string, timeout)"
 Expect string - waits for string to match or timeout before continuing.
-Supports regular expressions. Special characters must be escaped with '\\\\'.
+Supports regular expressions. Special characters must be escaped with '\e\e'.
 Timeout is in milliseconds, defaults to 0 meaning it will wait forever.
 
 Returns 1 on successful match, 0 on timeout, or -1 on error.


### PR DESCRIPTION
Literal backslash needs to be written as \e.

Lintian found this. Explanation:

```
$ lintian-explain-tags  acute-accent-in-manual-page
N:
I: acute-accent-in-manual-page
N:
N:   This manual page uses the \' groff sequence. Usually, the intent is to
N:   generate an apostrophe, but that sequence actually renders as an acute
N:   accent.
N:
N:   For an apostrophe or a single closing quote, use plain '. For single
N:   opening quote, i.e. a straight downward line ' like the one used in
N:   shell commands, use '\(aq'.
N:
N:   In case this tag was emitted for the second half of a '\\' sequence, this
N:   is indeed no acute accent, but still wrong: A literal backslash should be
N:   written \e in the groff format, i.e. a '\\' sequence needs to be changed
N:   to '\e' which also won't trigger this tag.
N:
N:   Please refer to Bug#554897, Bug#507673, and Bug#966803 for details.
N:
N:   Visibility: info
N:   Show-Always: no
N:   Check: documentation/manual
N:   Renamed from: acute-accent-in-manpage
N:
```
