### PR TITLE
Disable stdout buffering globally

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -61,6 +61,10 @@ int main(int argc, char *argv[])
     /* Configure tty device */
     tty_configure();
 
+    /* Disable line buffering in stdout. This is necessary if we
+     * want things like local echo to work correctly. */
+    setvbuf(stdout, NULL, _IONBF, 0);
+
     /* Configure input terminal */
     if (isatty(fileno(stdin)))
     {

--- a/src/tty.c
+++ b/src/tty.c
@@ -1184,10 +1184,6 @@ void stdout_configure(void)
 {
     int status;
 
-    /* Disable line buffering in stdout. This is necessary if we
-     * want things like local echo to work correctly. */
-    setvbuf(stdout, NULL, _IONBF, 0);
-
     /* Save current stdout settings */
     if (tcgetattr(STDOUT_FILENO, &stdout_old) < 0)
     {


### PR DESCRIPTION
This makes it possible to pipe output to other programs cleanly.