### PR TITLE
Fix --auto new and --auto latest on MacOS. (redo)

### DIFF
--- a/src/tty.c
+++ b/src/tty.c
@@ -1938,7 +1938,7 @@ char *getDeviceLocation(io_object_t device)
 // for __APPLE__
 GList *tty_search_for_serial_devices(void)
 {
-    GList *device_list = NULL;
+    search_reset();
     io_iterator_t iter = IO_OBJECT_NULL;
     CFMutableDictionaryRef matchingDict = NULL;
     listing_device_name_length_max = 0;


### PR DESCRIPTION
Git is being dumb about
https://github.com/tio/tio/commit/67c071633dc6d659fae1e529a85f5990531e1669 This PR is identical to that one and will supercede it.

Fix --auto new and --auto latest on MacOS.

'device_list' was both a global (eww!) and a local inside tty_search_for_serial_devices(). The local got set and returned, so it looked sane, but the caller used the global instead of the return value of the function it had just called, meaning (global) device_list was NULL while (ignored, local) device_list held a perfectly lovely linked list.

Tested:
tio --auto new waits for a new device to appare and connects tio --latest will connect to the most recently attached device
  which, in most worlds, is the most recently enumerated USB
  device, conveniently skipping all the bluetooth nonsense.
  If the lone USB device is disconnected, it then connects to
  one of those, meaning you really do have to restart tio.