### PR TITLE
fix: lua script stops output if it includes null termination

### DIFF
--- a/src/script.c
+++ b/src/script.c
@@ -187,7 +187,9 @@ static int modem_send(lua_State *L)
 // lua: send(string)
 static int write_(lua_State *L)
 {
-    const char *string = lua_tostring(L, 1);
+    size_t len = 0;
+    const char *string = lua_tolstring(L, 1, &len);
+
     int ret;
 
     if (string == NULL)
@@ -195,7 +197,7 @@ static int write_(lua_State *L)
         return 0;
     }
 
-    ret = write(device_fd, string, strlen(string));
+    ret = write(device_fd, string, len);
     fsync(device_fd);  // flush these characters now
     tcdrain(device_fd); //ensure we flushed characters to our device
 


### PR DESCRIPTION
This PR fixes the problem of the Lua script stopping output if it has an output that includes a null termination. For example, the following Lua script:

```lua
write("\x01\x02\x03\x04\x00\x05\x06\x07\x08")
```

outputs only the following bytes (hex mode) in the current head of master f887756a7159967e015e3422e9ab04a82db8945f

```shell
01 02 03 04
```
