### PR TITLE
Fix string truncation bug in scripting api

### DIFF
--- a/src/script.c
+++ b/src/script.c
@@ -332,7 +332,11 @@ error_rs:
     lua_pushnumber(L, ret);
     if (buffer != NULL)
     {
-        lua_pushstring(L, ret > 0 ? buffer : "");
+        if (ret > 0) {
+            lua_pushlstring(L, buffer, ret);
+        } else {
+            lua_pushstring(L, "");
+        }
         free(buffer);
     }
     else
@@ -400,7 +404,7 @@ static int read_line(lua_State *L)
 
 error_rl:
     lua_pushnumber(L, ret);
-    lua_pushstring(L, linebuf);
+    lua_pushlstring(L, linebuf, ret);
     return 2;
 }
 


### PR DESCRIPTION
In Lua, strings may contain null characters, this means when working with the Lua C API you must always use `lua_pushlstring` instead of `lua_pushstring` if there is no guarantee that the string contains no null bytes. Treating Lua strings as if they were C strings can result in them being truncated.