### PR TITLE
Fix device description-Linux

### DIFF
--- a/src/tty.c
+++ b/src/tty.c
@@ -1785,16 +1785,20 @@ GList *tty_search_for_serial_devices(void)
         creation_time = fs_get_creation_time(path);
         double uptime = current_time - creation_time;
 
-        // Read sysfs files to get best possible description of the driver
+        // Read sysfs files to get best possible description
         char description[50] = {};
-        length = fs_read_file_stripped(description, sizeof(description), "/sys/class/tty/%s/device/interface", entry->d_name);
-        if (length == -1)
-        {
-            length = fs_read_file_stripped(description, sizeof(description), "/sys/class/tty/%s/device/../interface", entry->d_name);
-        }
+        length = fs_read_file_stripped(description, sizeof(description), "/sys/class/tty/%s/device/../product", entry->d_name);
         if (length == -1)
         {
             length = fs_read_file_stripped(description, sizeof(description), "/sys/class/tty/%s/device/../../product", entry->d_name);
+        }
+        if (length == -1)
+        {
+            length = fs_read_file_stripped(description, sizeof(description), "/sys/class/tty/%s/device/interface", entry->d_name);
+        }
+        if (length == -1)
+        {
+            length = fs_read_file_stripped(description, sizeof(description), "/sys/class/tty/%s/device/../interface", entry->d_name);
         }
         if (length == -1)
         {


### PR DESCRIPTION
This commit only effects Linux.

The description field of the `device_list`, populated by `tty_search_for_serial_devices()`, was either incorrect or less than ideal for CDC ACM virtual com ports. For instance:
    (i) Some devices incorrectly have the description field populated by
    the 'product' property of USB hub they are connected via.
    (ii) Other devices have description fields populated with the interface,
    e.g. CDC, when there is a 'product' property available that would give a
    clearer description.

To solve these issues, we first prioritise searching for the 'product' property of the device over the 'interface' property. We also look for the 'product' property in an additional directory.