### PR TITLE
Add --complete-profiles to help printout

### DIFF
--- a/man/tio.1.in
+++ b/man/tio.1.in
@@ -372,6 +372,10 @@ Default value is "always".
 Execute shell command with I/O redirected to device
 
 .TP
+.BR "\-\-complete-profiles
+
+Prints profiles (for shell completion)
+.TP
 .BR \-v ", " \-\-version
 
 Display program version.

--- a/man/tio.1.txt
+++ b/man/tio.1.txt
@@ -289,6 +289,10 @@ OPTIONS
 
               Execute shell command with I/O redirected to device
 
+       --complete-profiles
+
+              Prints profiles (for shell completion)
+
        -v, --version
 
               Display program version.

--- a/src/bash-completion/tio.in
+++ b/src/bash-completion/tio.in
@@ -46,6 +46,7 @@ _tio()
              --script-file \
              --script-run \
              --exec \
+             --complete-profiles \
           -v --version \
           -h --help"
 

--- a/src/options.c
+++ b/src/options.c
@@ -171,6 +171,7 @@ void option_print_help(char *argv[])
     printf("      --script-file <filename>           Run script from file\n");
     printf("      --script-run once|always|never     Run script on connect (default: always)\n");
     printf("      --exec <command>                   Execute shell command with I/O redirected to device\n");
+    printf("      --complete-profiles                Prints profiles (for shell completion)\n");
     printf("  -v, --version                          Display version\n");
     printf("  -h, --help                             Display help\n");
     printf("\n");


### PR DESCRIPTION
I only discovered this argument existed after digging into the source code, figured it'd be nice to expose to users.