### PR TITLE
Add option --no-tty-restore / -N that  omits tty_restore() call

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -65,6 +65,7 @@ Lubov66 <radolevanja@gmail.com>
 V <v@anomalous.eu>
 Samuel Holland <samuel@sholland.org>
 David Ordnung <david.ordnung@googlemail.com>
+Erling Sigurdson <efimov-d-v@yandex.ru>
 
 
 Thanks to everyone who has contributed to this project.

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Options:
       --exclude-drivers <pattern>        Exclude drivers by pattern
       --exclude-tids <pattern>           Exclude topology IDs by pattern
   -n, --no-reconnect                     Do not reconnect
+  -N, --no-tty-restore                   Do not restore initial TTY device settings
   -e, --local-echo                       Enable local echo
       --input-mode normal|hex|line       Select input mode (default: normal)
       --output-mode normal|hex|hexN      Select output mode (default: normal)

--- a/examples/config/config
+++ b/examples/config/config
@@ -19,6 +19,7 @@ output-delay = 0
 output-line-delay = 0
 auto-connect = direct
 no-reconnect = false
+no-tty-restore = false
 local-echo = false
 input-mode = normal
 output-mode = normal

--- a/man/tio.1.in
+++ b/man/tio.1.in
@@ -124,6 +124,14 @@ This means that tio will exit if it fails to connect to device or an
 established connection is lost.
 
 .TP
+.BR \-n ", " \-\-no\-tty\-restore
+
+Do not restore initial TTY device settings.
+
+This means that tio will exit without trying to restore TTY device
+settings that existed when tio was started.
+
+.TP
 .BR \-e ", " "\-\-local\-echo
 
 Enable local echo.

--- a/man/tio.1.txt
+++ b/man/tio.1.txt
@@ -94,6 +94,12 @@ OPTIONS
 
               This means that tio will exit if it fails to connect to device or an established connection is lost.
 
+       -N, --no-tty-restore
+
+              Do not restore initial TTY device settings.
+
+              This means that tio will exit without trying to restore TTY device settings that existed when tio was started.
+
        -e, --local-echo
 
               Enable local echo.

--- a/src/bash-completion/tio.in
+++ b/src/bash-completion/tio.in
@@ -23,6 +23,7 @@ _tio()
              --exclude-drivers \
              --exclude-tids \
           -n --no-reconnect \
+          -N --no-tty-restore \
           -e --local-echo \
           -l --log \
              --log-file \

--- a/src/configfile.c
+++ b/src/configfile.c
@@ -189,6 +189,7 @@ static void config_parse_keys(GKeyFile *key_file, char *group)
     config_get_string(key_file, group, "exclude-drivers", &option.exclude_devices, NULL);
     config_get_string(key_file, group, "exclude-tids", &option.exclude_devices, NULL);
     config_get_bool(key_file, group, "no-reconnect", &option.no_reconnect);
+    config_get_bool(key_file, group, "no-tty-restore", &option.no_tty_restore);
     config_get_bool(key_file, group, "local-echo", &option.local_echo);
     config_get_string(key_file, group, "input-mode", &string, "normal", "hex", "line", NULL);
     if (string != NULL)

--- a/src/options.c
+++ b/src/options.c
@@ -79,6 +79,7 @@ struct option_t option =
     .dcd_pulse_duration = 100,
     .ri_pulse_duration = 100,
     .no_reconnect = false,
+    .no_tty_restore = false,
     .auto_connect = AUTO_CONNECT_DIRECT,
     .log = false,
     .log_append = false,
@@ -148,6 +149,7 @@ void option_print_help(char *argv[])
     printf("      --exclude-drivers <pattern>        Exclude drivers by pattern\n");
     printf("      --exclude-tids <pattern>           Exclude topology IDs by pattern\n");
     printf("  -n, --no-reconnect                     Do not reconnect\n");
+    printf("  -N, --no-tty-restore                   Do not restore initial TTY device settings\n");
     printf("  -e, --local-echo                       Enable local echo\n");
     printf("      --input-mode normal|hex|line       Select input mode (default: normal)\n");
     printf("      --output-mode normal|hex|hexN      Select output mode (default: normal)\n");
@@ -833,6 +835,7 @@ void options_print()
     tio_printf(" Output line delay: %d", option.output_line_delay);
     tio_printf(" Automatic connect strategy: %s", option_auto_connect_state_to_string(option.auto_connect));
     tio_printf(" Automatic reconnect: %s", option.no_reconnect ? "true" : "false");
+    tio_printf(" TTY device settings restore: %s", option.no_tty_restore ? "true" : "false");
     tio_printf(" Pulse duration: DTR=%d RTS=%d CTS=%d DSR=%d DCD=%d RI=%d", option.dtr_pulse_duration,
                                                                             option.rts_pulse_duration,
                                                                             option.cts_pulse_duration,
@@ -904,6 +907,7 @@ void options_parse(int argc, char *argv[])
             {"exclude-drivers",      required_argument, 0, OPT_EXCLUDE_DRIVERS     },
             {"exclude-tids",         required_argument, 0, OPT_EXCLUDE_TIDS        },
             {"no-reconnect",         no_argument,       0, 'n'                     },
+            {"no-tty-restore",       no_argument,       0, 'N'                     },
             {"local-echo",           no_argument,       0, 'e'                     },
             {"timestamp",            no_argument,       0, 't'                     },
             {"timestamp-format",     required_argument, 0, OPT_TIMESTAMP_FORMAT    },
@@ -937,7 +941,7 @@ void options_parse(int argc, char *argv[])
         int option_index = 0;
 
         /* Parse argument using getopt_long */
-        c = getopt_long(argc, argv, "b:d:f:s:p:o:O:a:netLlS:m:c:xrvh", long_options, &option_index);
+        c = getopt_long(argc, argv, "b:d:f:s:p:o:O:a:nNetLlS:m:c:xrvh", long_options, &option_index);
 
         /* Detect the end of the options */
         if (c == -1)
@@ -1005,6 +1009,10 @@ void options_parse(int argc, char *argv[])
 
             case 'n':
                 option.no_reconnect = true;
+                break;
+
+            case 'N':
+                option.no_tty_restore = true;
                 break;
 
             case 'e':

--- a/src/options.h
+++ b/src/options.h
@@ -61,6 +61,7 @@ struct option_t
     int dcd_pulse_duration;
     int ri_pulse_duration;
     bool no_reconnect;
+    bool no_tty_restore;
     auto_connect_t auto_connect;
     bool log;
     bool log_append;

--- a/src/tty.c
+++ b/src/tty.c
@@ -2600,10 +2600,13 @@ int tty_connect(void)
         rs485_mode_enable(device_fd);
     }
 
-    /* Make sure we restore tty settings on exit */
+    /* Make sure we restore tty settings on exit unless ordered to keep current settings */
     if (first)
     {
-        atexit(&tty_restore);
+        if (option.no_tty_restore == false)
+        {
+            atexit(&tty_restore);
+        }
         first = false;
     }
 


### PR DESCRIPTION
This is an attempt to address this issue: https://github.com/tio/tio/issues/334

Unfortunately, for now I've found the only reliable way to allow non-interactive transmissions actually finish (not just clear the buffer, but let the data reach its destination before TTY settings get restored): dismiss the `atexit(&tty_restore)` call. In order to avoid messing with the baseline execution flow, I decided to make it an option, not a mainstream.

Experiments with `tcdrain()`, `tcsetattr(..., TCSADRAIN, ...)`, `tcflow()` and `ioctl(device_fd, TIOCOUTQ, &...)` didn't bring any useful result.

That being said, even this way isn't 100% reliable: when using `--no-tty-restore` / `-N` in non-interactive mode, my data reaches the TTY device (CH340 chip in my case) only starting from second attempt (not EVERY second attempt, it's just that the first attempt always fails, but subsequent ones are always successful).

I tried to comply with your code style and option documentation as hard as I could.

Best regards for FOSS crowd.